### PR TITLE
Fix docker-up: revert pointless VOITTA_DATA_DIR split

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -5,17 +5,14 @@ MCP_PORT=8001
 MCP_TRANSPORT=streamable-http  # streamable-http (default) or sse (for Claude Code)
 MCP_SEARCH_LIMIT=20  # Default number of search results
 
-# Data directory (parent of fs/, qdrant/, voitta.db).
-# Used by docker-compose for volume mounts.
-VOITTA_DATA_DIR=/Users/nmit17/DEVEL/voitta-rag-data
+# Root path for all persistent data (absolute path on host).
+# Contains: fs/ (managed files), qdrant/ (vector storage), voitta.db (SQLite).
+# Docker-compose mounts this as /data and overrides in-container paths.
+VOITTA_ROOT_PATH=/Users/nmit17/DEVEL/voitta-rag-data
 
-# Root path for managed files (absolute path on host).
-# Docker-compose overrides to /data/fs.
-VOITTA_ROOT_PATH=/Users/nmit17/DEVEL/voitta-rag-data/fs
-
-# Database path (absolute for local dev).
+# Database path (relative to VOITTA_ROOT_PATH for local dev).
 # Docker-compose overrides to /data/voitta.db.
-VOITTA_DB_PATH=/Users/nmit17/DEVEL/voitta-rag-data/voitta.db
+VOITTA_DB_PATH=voitta.db
 
 # Server settings
 VOITTA_HOST=0.0.0.0

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,7 +5,7 @@ services:
       - "6333:6333"
       - "6334:6334"
     volumes:
-      - ${VOITTA_DATA_DIR}/qdrant:/qdrant/storage
+      - ${VOITTA_ROOT_PATH}/qdrant:/qdrant/storage
 
   voitta-rag:
     build: .
@@ -18,7 +18,7 @@ services:
       - VOITTA_DB_PATH=/data/voitta.db
       - HF_HOME=/root/.cache/huggingface
     volumes:
-      - ${VOITTA_DATA_DIR}:/data
+      - ${VOITTA_ROOT_PATH}:/data
       - ./users.txt:/app/users.txt:ro
       - ${SSH_KEY_DIR:-~/.ssh}:/root/.ssh:ro
       - ${MODEL_CACHE_DIR:-~/.cache/huggingface}:/root/.cache/huggingface


### PR DESCRIPTION
## Summary

- **Reverts the unnecessary `VOITTA_DATA_DIR` variable** introduced in ec8e9bf that broke `make docker-up` for everyone
- Docker compose volumes resolved to `:/data` (empty left side) because `VOITTA_DATA_DIR` was never added to `.env` -- only to `.env.example` where it sits collecting dust
- We had ONE variable (`VOITTA_ROOT_PATH`) that worked perfectly. Then someone decided we needed TWO variables pointing to the same directory tree. Why? Because `fs/`, `qdrant/`, and `voitta.db` living under one roof was apparently too simple and needed to be made enterprise-grade

## What broke

```
invalid spec: :/data: empty section between colons
make: *** [docker-up] Error 1
```

## The fix

Put `VOITTA_ROOT_PATH` back where it belongs in `docker-compose.yml`. Delete `VOITTA_DATA_DIR` from `.env.example`. One path. One variable. Like God intended.

## Test plan

- [x] `make docker-up` actually works now
- [x] Both containers come up healthy
- [ ] @illegalplumbing promises to run `make docker-up` before pushing next time