### PR TITLE
Add source timestamp tracking to sync connectors and indexing pipeline

### DIFF
--- a/src/voitta/db/models.py
+++ b/src/voitta/db/models.py
@@ -173,6 +173,8 @@ class IndexedFile(Base):
     content_hash: Mapped[str] = mapped_column(String(64), nullable=False)  # SHA-256
     file_size: Mapped[int] = mapped_column(Integer, nullable=False)
     chunk_count: Mapped[int] = mapped_column(Integer, default=0)
+    source_created_at: Mapped[int | None] = mapped_column(Integer, nullable=True)
+    source_modified_at: Mapped[int | None] = mapped_column(Integer, nullable=True)
     indexed_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), default=utc_now)
     updated_at: Mapped[datetime] = mapped_column(
         DateTime(timezone=True), default=utc_now, onupdate=utc_now

--- a/src/voitta/services/sync/azure_devops.py
+++ b/src/voitta/services/sync/azure_devops.py
@@ -329,12 +329,15 @@ class AzureDevOpsConnector(BaseSyncConnector):
 
                 content_hash = hashlib.sha256(f"{rev}:{changed_date}".encode()).hexdigest()
 
+                created_date = fields.get("System.CreatedDate", "")
+
                 files.append(
                     RemoteFile(
                         remote_path=remote_path,
                         size=0,
                         modified_at=changed_date,
                         content_hash=content_hash,
+                        created_at=created_date,
                     )
                 )
 
@@ -535,6 +538,18 @@ class AzureDevOpsConnector(BaseSyncConnector):
                     dirpath.rmdir()
                 except Exception:
                     pass
+
+        # Write timestamps sidecar for the indexing pipeline
+        timestamps = {}
+        for rf in remote_files:
+            entry = {}
+            if rf.modified_at:
+                entry["modified_at"] = rf.modified_at
+            if rf.created_at:
+                entry["created_at"] = rf.created_at
+            if entry:
+                timestamps[rf.remote_path] = entry
+        (local_root / ".voitta_timestamps.json").write_text(json.dumps(timestamps))
 
         hash_file.write_text(json.dumps(new_revisions), encoding="utf-8")
         logger.info("Sync complete for %s: %s", folder_path, stats)

--- a/src/voitta/services/sync/box.py
+++ b/src/voitta/services/sync/box.py
@@ -160,7 +160,7 @@ class BoxConnector(BaseSyncConnector):
             resp = await client.get(
                 f"{BOX_API_BASE}/folders/{folder_id}/items",
                 params={
-                    "fields": "name,size,modified_at,sha1,type",
+                    "fields": "name,size,modified_at,created_at,sha1,type",
                     "limit": limit,
                     "offset": offset,
                 },
@@ -198,6 +198,7 @@ class BoxConnector(BaseSyncConnector):
                             size=entry.get("size", 0),
                             modified_at=entry.get("modified_at", ""),
                             content_hash=entry.get("sha1"),
+                            created_at=entry.get("created_at", ""),
                         )
                     )
 

--- a/src/voitta/services/sync/google_drive.py
+++ b/src/voitta/services/sync/google_drive.py
@@ -244,7 +244,7 @@ class GoogleDriveConnector(BaseSyncConnector):
                 service.files()
                 .list(
                     q=f"'{folder_id}' in parents and trashed = false",
-                    fields="nextPageToken, files(id, name, mimeType, size, modifiedTime, md5Checksum)",
+                    fields="nextPageToken, files(id, name, mimeType, size, modifiedTime, createdTime, md5Checksum)",
                     pageSize=1000,
                     pageToken=page_token,
                     supportsAllDrives=True,
@@ -266,6 +266,7 @@ class GoogleDriveConnector(BaseSyncConnector):
                             size=0,  # native Google files have no size
                             modified_at=item.get("modifiedTime", ""),
                             content_hash=None,
+                            created_at=item.get("createdTime", ""),
                         )
                     )
                 elif mime.startswith("application/vnd.google-apps."):
@@ -278,6 +279,7 @@ class GoogleDriveConnector(BaseSyncConnector):
                             size=int(item.get("size", 0)),
                             modified_at=item.get("modifiedTime", ""),
                             content_hash=item.get("md5Checksum"),
+                            created_at=item.get("createdTime", ""),
                         )
                     )
 

--- a/src/voitta/services/sync/sharepoint.py
+++ b/src/voitta/services/sync/sharepoint.py
@@ -247,6 +247,7 @@ class SharePointConnector(BaseSyncConnector):
                             content_hash=item.get("file", {})
                             .get("hashes", {})
                             .get("sha256Hash"),
+                            created_at=item.get("createdDateTime", ""),
                         )
                     )
 


### PR DESCRIPTION
Propagate created_at/modified_at from remote sources (SharePoint, Box, Google Drive, Confluence, Jira, Azure DevOps, GitHub) through a .voitta_timestamps.json sidecar file into the indexing service and vector store, enabling time-based filtering and sorting of search results.