### PR TITLE
Jira/Confluence Cloud auth and sync error toasts

### DIFF
--- a/src/voitta/api/routes/sync.py
+++ b/src/voitta/api/routes/sync.py
@@ -63,13 +63,17 @@ class AzureDevOpsConfig(BaseModel):
 class JiraConfig(BaseModel):
     url: str  # https://jira.example.com or https://jira.example.com/browse/PROJ
     project: str = ""  # Project key (e.g., PROJ)
-    token: str = ""  # Personal Access Token
+    token: str = ""  # Personal Access Token (Server/DC) or API Token (Cloud)
+    auth_method: str = "cloud"  # "cloud" or "server"
+    email: str = ""  # Atlassian account email (required for Cloud)
 
 
 class ConfluenceConfig(BaseModel):
     url: str  # https://confluence.example.com
     space: str = ""  # Space key (e.g., DAIHUB)
-    token: str = ""  # Personal Access Token
+    token: str = ""  # Personal Access Token (Server/DC) or API Token (Cloud)
+    auth_method: str = "cloud"  # "cloud" or "server"
+    email: str = ""  # Atlassian account email (required for Cloud)
 
 
 class BoxConfig(BaseModel):
@@ -173,12 +177,16 @@ def _to_response(source: FolderSyncSource) -> SyncSourceResponse:
             url=source.jira_url or "",
             project=source.jira_project or "",
             token=source.jira_token or "",
+            auth_method=source.jira_auth_method or "cloud",
+            email=source.jira_email or "",
         )
     elif source.source_type == "confluence":
         confluence = ConfluenceConfig(
             url=source.confluence_url or "",
             space=source.confluence_space or "",
             token=source.confluence_token or "",
+            auth_method=source.confluence_auth_method or "cloud",
+            email=source.confluence_email or "",
         )
     elif source.source_type == "box":
         box = BoxConfig(
@@ -590,8 +598,8 @@ async def upsert_sync_source(
         "gh_auth_method", "gh_username", "gh_pat", "gh_all_branches",
         "ado_tenant_id", "ado_client_id", "ado_client_secret",
         "ado_organization", "ado_project", "ado_url",
-        "jira_url", "jira_project", "jira_token",
-        "confluence_url", "confluence_space", "confluence_token",
+        "jira_url", "jira_project", "jira_token", "jira_auth_method", "jira_email",
+        "confluence_url", "confluence_space", "confluence_token", "confluence_auth_method", "confluence_email",
         "box_client_id", "box_client_secret", "box_folder_id",
     ):
         setattr(source, field, None)
@@ -638,6 +646,8 @@ async def upsert_sync_source(
     elif request.source_type == "jira" and request.jira:
         from ...services.sync.jira import _parse_jira_url
         source.jira_token = request.jira.token
+        source.jira_auth_method = request.jira.auth_method or "cloud"
+        source.jira_email = request.jira.email
         # Try to parse URL for base URL and project
         try:
             base_url, project_key = _parse_jira_url(request.jira.url)
@@ -648,9 +658,15 @@ async def upsert_sync_source(
             source.jira_url = request.jira.url
             source.jira_project = request.jira.project
     elif request.source_type == "confluence" and request.confluence:
-        source.confluence_url = request.confluence.url.rstrip("/")
+        conf_url = request.confluence.url.rstrip("/")
+        # Strip /wiki suffix if user included it (Cloud adds it automatically)
+        if conf_url.endswith("/wiki"):
+            conf_url = conf_url[:-5]
+        source.confluence_url = conf_url
         source.confluence_space = request.confluence.space.upper()
         source.confluence_token = request.confluence.token
+        source.confluence_auth_method = request.confluence.auth_method or "cloud"
+        source.confluence_email = request.confluence.email
     elif request.source_type == "box" and request.box:
         source.box_client_id = request.box.client_id
         source.box_client_secret = request.box.client_secret

--- a/src/voitta/db/models.py
+++ b/src/voitta/db/models.py
@@ -179,11 +179,15 @@ class FolderSyncSource(Base):
     jira_url: Mapped[str | None] = mapped_column(String(1000), nullable=True)
     jira_project: Mapped[str | None] = mapped_column(String(255), nullable=True)
     jira_token: Mapped[str | None] = mapped_column(String(500), nullable=True)
+    jira_auth_method: Mapped[str | None] = mapped_column(String(20), nullable=True)  # "cloud" or "server"
+    jira_email: Mapped[str | None] = mapped_column(String(255), nullable=True)  # For Cloud basic auth
 
     # Confluence credentials
     confluence_url: Mapped[str | None] = mapped_column(String(1000), nullable=True)
     confluence_space: Mapped[str | None] = mapped_column(String(255), nullable=True)
     confluence_token: Mapped[str | None] = mapped_column(String(500), nullable=True)
+    confluence_auth_method: Mapped[str | None] = mapped_column(String(20), nullable=True)  # "cloud" or "server"
+    confluence_email: Mapped[str | None] = mapped_column(String(255), nullable=True)  # For Cloud basic auth
 
     # Box credentials (OAuth 2.0)
     box_client_id: Mapped[str | None] = mapped_column(String(255), nullable=True)

--- a/src/voitta/services/sync/confluence.py
+++ b/src/voitta/services/sync/confluence.py
@@ -1,5 +1,6 @@
-"""Confluence sync connector - Pages from Confluence Server/Data Center."""
+"""Confluence sync connector - Pages from Confluence Cloud and Server/Data Center."""
 
+import base64
 import hashlib
 import json
 import logging
@@ -169,15 +170,33 @@ def _render_page_md(page: dict, attachments: list) -> str:
 
 class ConfluenceConnector(BaseSyncConnector):
 
-    def _headers(self, token: str) -> dict:
-        """Build auth headers for Confluence Server/DC with PAT."""
-        return {
-            "Authorization": f"Bearer {token}",
-            "Content-Type": "application/json",
-        }
+    def _is_cloud(self, source) -> bool:
+        retval = (source.confluence_auth_method or "cloud") == "cloud"
+        return retval
+
+    def _headers(self, source) -> dict:
+        """Build auth headers - Basic for Cloud, Bearer for Server/DC."""
+        if self._is_cloud(source):
+            credentials = f"{source.confluence_email}:{source.confluence_token}"
+            b64 = base64.b64encode(credentials.encode()).decode()
+            retval = {
+                "Authorization": f"Basic {b64}",
+                "Content-Type": "application/json",
+            }
+        else:
+            retval = {
+                "Authorization": f"Bearer {source.confluence_token}",
+                "Content-Type": "application/json",
+            }
+        return retval
 
     def _api_base(self, source) -> str:
-        return f"{source.confluence_url}/rest/api"
+        # Cloud uses /wiki/rest/api, Server uses /rest/api
+        if self._is_cloud(source):
+            retval = f"{source.confluence_url}/wiki/rest/api"
+        else:
+            retval = f"{source.confluence_url}/rest/api"
+        return retval
 
     async def _get_all_pages_in_space(self, client, headers, base_url, space_key) -> list[dict]:
         """Get all pages in a space with pagination."""
@@ -240,9 +259,11 @@ class ConfluenceConnector(BaseSyncConnector):
             raise RuntimeError("Confluence token not configured")
         if not source.confluence_space:
             raise RuntimeError("Confluence space not configured")
+        if self._is_cloud(source) and not source.confluence_email:
+            raise RuntimeError("Confluence Cloud requires an email address")
 
         files: list[RemoteFile] = []
-        headers = self._headers(source.confluence_token)
+        headers = self._headers(source)
         base = self._api_base(source)
 
         async with httpx.AsyncClient(timeout=60.0) as client:
@@ -294,7 +315,7 @@ class ConfluenceConnector(BaseSyncConnector):
             raise RuntimeError(f"Cannot parse page ID from path: {remote_path}")
         page_id = m.group(1)
 
-        headers = self._headers(source.confluence_token)
+        headers = self._headers(source)
         base = self._api_base(source)
 
         async with httpx.AsyncClient(timeout=30.0) as client:

--- a/src/voitta/services/sync/jira.py
+++ b/src/voitta/services/sync/jira.py
@@ -1,5 +1,6 @@
-"""Jira sync connector - Issues, boards, and sprints from Jira Server/Data Center."""
+"""Jira sync connector - Issues, boards, and sprints from Jira Cloud and Server/Data Center."""
 
+import base64
 import hashlib
 import json
 import logging
@@ -325,12 +326,27 @@ def _render_issue_md(
 
 class JiraConnector(BaseSyncConnector):
 
-    def _headers(self, token: str) -> dict:
-        """Build auth headers for Jira Server/DC with PAT."""
-        return {
-            "Authorization": f"Bearer {token}",
-            "Content-Type": "application/json",
-        }
+    def _is_cloud(self, source) -> bool:
+        retval = (source.jira_auth_method or "cloud") == "cloud"
+        return retval
+
+    def _headers(self, source) -> dict:
+        """Build auth headers - Basic for Cloud, Bearer for Server/DC."""
+        if self._is_cloud(source):
+            if not source.jira_email:
+                raise RuntimeError("Jira Cloud requires an email address. Re-save the sync config with your Atlassian email.")
+            credentials = f"{source.jira_email}:{source.jira_token}"
+            b64 = base64.b64encode(credentials.encode()).decode()
+            retval = {
+                "Authorization": f"Basic {b64}",
+                "Content-Type": "application/json",
+            }
+        else:
+            retval = {
+                "Authorization": f"Bearer {source.jira_token}",
+                "Content-Type": "application/json",
+            }
+        return retval
 
     def _api_base(self, source) -> str:
         return f"{source.jira_url}/rest/api/2"
@@ -342,7 +358,7 @@ class JiraConnector(BaseSyncConnector):
 
     async def _fetch_field_mapping(self, source) -> dict[str, str]:
         """Discover custom field IDs for sprint, story points, etc."""
-        headers = self._headers(source.jira_token)
+        headers = self._headers(source)
         base = self._api_base(source)
         mapping: dict[str, str] = {}
 
@@ -375,7 +391,7 @@ class JiraConnector(BaseSyncConnector):
 
     async def _sync_boards(self, source, local_root: Path) -> int:
         """Sync board and sprint data from the Agile API. Returns file count."""
-        headers = self._headers(source.jira_token)
+        headers = self._headers(source)
         agile = self._agile_base(source)
         count = 0
 
@@ -540,73 +556,118 @@ class JiraConnector(BaseSyncConnector):
             raise RuntimeError("Jira token not configured")
         if not source.jira_project:
             raise RuntimeError("Jira project not configured")
+        if self._is_cloud(source) and not source.jira_email:
+            raise RuntimeError("Jira Cloud requires an email address")
 
         files: list[RemoteFile] = []
-        headers = self._headers(source.jira_token)
-        base = self._api_base(source)
+        headers = self._headers(source)
+
+        is_cloud = self._is_cloud(source)
 
         async with httpx.AsyncClient(timeout=60.0) as client:
-            start_at = 0
-            max_results = 100
-            total = None
+            jql = f"project = {source.jira_project} ORDER BY updated DESC"
 
-            while total is None or start_at < total:
-                # JQL to get all issues in project
-                jql = f"project = {source.jira_project} ORDER BY updated DESC"
-                resp = await client.get(
-                    f"{base}/search",
-                    params={
+            if is_cloud:
+                # Cloud: use v3 search/jql endpoint (v2/search is deprecated)
+                next_page_token = None
+                while True:
+                    params = {
                         "jql": jql,
-                        "startAt": start_at,
-                        "maxResults": max_results,
+                        "maxResults": 100,
                         "fields": "key,issuetype,summary,updated,created",
-                    },
-                    headers=headers,
-                )
+                    }
+                    if next_page_token:
+                        params["nextPageToken"] = next_page_token
 
-                if resp.status_code == 401:
-                    raise RuntimeError("Jira authentication failed. Check your token.")
-                if resp.status_code != 200:
-                    raise RuntimeError(
-                        f"Jira search failed ({resp.status_code}): {resp.text[:500]}"
+                    resp = await client.get(
+                        f"{source.jira_url}/rest/api/3/search/jql",
+                        params=params,
+                        headers=headers,
                     )
 
-                data = resp.json()
-                total = data.get("total", 0)
-                issues = data.get("issues", [])
-
-                for issue in issues:
-                    key = issue["key"]
-                    flds = issue.get("fields", {})
-                    issue_type = (flds.get("issuetype") or {}).get("name", "Other")
-                    summary = flds.get("summary", f"Issue-{key}")
-                    updated = flds.get("updated", "")
-
-                    safe_summary = _sanitize_filename(summary)
-                    safe_type = _sanitize_filename(issue_type)
-                    remote_path = f"issues/{safe_type}/{key}-{safe_summary}.md"
-
-                    # Use updated timestamp as content hash for change detection
-                    content_hash = hashlib.sha256(updated.encode()).hexdigest()
-
-                    created = flds.get("created", "")
-
-                    files.append(
-                        RemoteFile(
-                            remote_path=remote_path,
-                            size=0,
-                            modified_at=updated,
-                            content_hash=content_hash,
-                            created_at=created,
+                    if resp.status_code == 401:
+                        raise RuntimeError("Jira authentication failed. Check your email and API token.")
+                    if resp.status_code == 403:
+                        raise RuntimeError(
+                            f"Jira access denied. Verify your email and API token. ({resp.text[:300]})"
                         )
+                    if resp.status_code != 200:
+                        raise RuntimeError(
+                            f"Jira search failed ({resp.status_code}): {resp.text[:500]}"
+                        )
+
+                    data = resp.json()
+                    issues = data.get("issues", [])
+                    self._append_issues(files, issues, source)
+
+                    if data.get("isLast", True) or not issues:
+                        break
+                    next_page_token = data.get("nextPageToken")
+                    if not next_page_token:
+                        break
+            else:
+                # Server/DC: use v2 search endpoint
+                base = self._api_base(source)
+                start_at = 0
+                max_results = 100
+                total = None
+
+                while total is None or start_at < total:
+                    resp = await client.get(
+                        f"{base}/search",
+                        params={
+                            "jql": jql,
+                            "startAt": start_at,
+                            "maxResults": max_results,
+                            "fields": "key,issuetype,summary,updated,created",
+                        },
+                        headers=headers,
                     )
 
-                start_at += max_results
-                if not issues:
-                    break
+                    if resp.status_code == 401:
+                        raise RuntimeError("Jira authentication failed. Check your PAT token.")
+                    if resp.status_code != 200:
+                        raise RuntimeError(
+                            f"Jira search failed ({resp.status_code}): {resp.text[:500]}"
+                        )
+
+                    data = resp.json()
+                    total = data.get("total", 0)
+                    issues = data.get("issues", [])
+                    self._append_issues(files, issues, source)
+
+                    start_at += max_results
+                    if not issues:
+                        break
 
         logger.info("Listed %d issues from Jira project %s", len(files), source.jira_project)
         return files
+
+    def _append_issues(self, files: list[RemoteFile], issues: list[dict], source) -> None:
+        """Extract RemoteFile entries from a list of Jira issue dicts."""
+        for issue in issues:
+            key = issue["key"]
+            flds = issue.get("fields", {})
+            issue_type = (flds.get("issuetype") or {}).get("name", "Other")
+            summary = flds.get("summary", f"Issue-{key}")
+            updated = flds.get("updated", "")
+
+            safe_summary = _sanitize_filename(summary)
+            safe_type = _sanitize_filename(issue_type)
+            remote_path = f"issues/{safe_type}/{key}-{safe_summary}.md"
+
+            content_hash = hashlib.sha256(updated.encode()).hexdigest()
+            created = flds.get("created", "")
+
+            files.append(
+                RemoteFile(
+                    remote_path=remote_path,
+                    size=0,
+                    modified_at=updated,
+                    content_hash=content_hash,
+                    created_at=created,
+                )
+            )
 
     # ---- download_file ----------------------------------------------------
 
@@ -627,7 +688,7 @@ class JiraConnector(BaseSyncConnector):
             raise RuntimeError(f"Cannot parse issue path: {remote_path}")
 
         issue_key = match.group(1)
-        headers = self._headers(source.jira_token)
+        headers = self._headers(source)
         base = self._api_base(source)
 
         async with httpx.AsyncClient(timeout=30.0) as client:

--- a/src/voitta/web/templates/browser.html
+++ b/src/voitta/web/templates/browser.html
@@ -315,15 +315,34 @@
                 <div id="sync-fields-jira" class="sync-fields" style="display: none;">
                     <div class="form-group-compact">
                         <label class="form-label-compact">Jira URL</label>
-                        <input type="text" id="jira-url" class="sync-input" placeholder="https://jira.example.com">
+                        <input type="text" id="jira-url" class="sync-input" placeholder="https://yourorg.atlassian.net">
                     </div>
                     <div class="form-group-compact">
                         <label class="form-label-compact">Project Key</label>
                         <input type="text" id="jira-project" class="sync-input" placeholder="PROJ">
                     </div>
                     <div class="form-group-compact">
-                        <label class="form-label-compact">Personal Access Token</label>
-                        <input type="text" id="jira-token" class="sync-input" placeholder="Your Jira PAT">
+                        <label class="form-label-compact">Auth Method</label>
+                        <select id="jira-auth-method" class="sync-select" onchange="toggleJiraAuth()">
+                            <option value="cloud">Cloud (API Token)</option>
+                            <option value="server">Server / Data Center (PAT)</option>
+                        </select>
+                    </div>
+                    <div id="jira-cloud-fields">
+                        <div class="form-group-compact">
+                            <label class="form-label-compact">Email</label>
+                            <input type="text" id="jira-email" class="sync-input" placeholder="your.email@company.com">
+                        </div>
+                        <div class="form-group-compact">
+                            <label class="form-label-compact">API Token</label>
+                            <input type="text" id="jira-token" class="sync-input" placeholder="Atlassian API token">
+                        </div>
+                    </div>
+                    <div id="jira-server-fields" style="display: none;">
+                        <div class="form-group-compact">
+                            <label class="form-label-compact">Personal Access Token</label>
+                            <input type="text" id="jira-token-server" class="sync-input" placeholder="Your Jira PAT">
+                        </div>
                     </div>
                 </div>
 
@@ -331,15 +350,34 @@
                 <div id="sync-fields-confluence" class="sync-fields" style="display: none;">
                     <div class="form-group-compact">
                         <label class="form-label-compact">Confluence URL</label>
-                        <input type="text" id="confluence-url" class="sync-input" placeholder="https://confluence.example.com">
+                        <input type="text" id="confluence-url" class="sync-input" placeholder="https://yourorg.atlassian.net (no /wiki)">
                     </div>
                     <div class="form-group-compact">
                         <label class="form-label-compact">Space Key</label>
                         <input type="text" id="confluence-space" class="sync-input" placeholder="DAIHUB">
                     </div>
                     <div class="form-group-compact">
-                        <label class="form-label-compact">Personal Access Token</label>
-                        <input type="text" id="confluence-token" class="sync-input" placeholder="Your Confluence PAT">
+                        <label class="form-label-compact">Auth Method</label>
+                        <select id="confluence-auth-method" class="sync-select" onchange="toggleConfluenceAuth()">
+                            <option value="cloud">Cloud (API Token)</option>
+                            <option value="server">Server / Data Center (PAT)</option>
+                        </select>
+                    </div>
+                    <div id="confluence-cloud-fields">
+                        <div class="form-group-compact">
+                            <label class="form-label-compact">Email</label>
+                            <input type="text" id="confluence-email" class="sync-input" placeholder="your.email@company.com">
+                        </div>
+                        <div class="form-group-compact">
+                            <label class="form-label-compact">API Token</label>
+                            <input type="text" id="confluence-token" class="sync-input" placeholder="Atlassian API token">
+                        </div>
+                    </div>
+                    <div id="confluence-server-fields" style="display: none;">
+                        <div class="form-group-compact">
+                            <label class="form-label-compact">Personal Access Token</label>
+                            <input type="text" id="confluence-token-server" class="sync-input" placeholder="Your Confluence PAT">
+                        </div>
                     </div>
                 </div>
 

--- a/static/js/app.js
+++ b/static/js/app.js
@@ -156,7 +156,12 @@ function handleSyncStatusEvent(event) {
                 refreshFileList();
             }
         }
-        // Status is already reflected in the sidebar UI — no toast needed
+        // Show toast for sync completion or error
+        if (event.sync_status === 'error' && event.sync_error) {
+            showToast('Sync failed: ' + event.sync_error, 'error');
+        } else if (event.sync_status === 'synced') {
+            showToast('Sync completed for ' + folderPath, 'success');
+        }
     }
 }
 
@@ -900,12 +905,13 @@ function showToast(message, type = 'info') {
 
     container.appendChild(toast);
 
-    // Auto-remove after 4 seconds
+    // Auto-remove: 8 seconds for errors, 4 seconds for others
+    const duration = type === 'error' ? 8000 : 4000;
     setTimeout(() => {
         toast.style.opacity = '0';
         toast.style.transform = 'translateX(100%)';
         setTimeout(() => toast.remove(), 300);
-    }, 4000);
+    }, duration);
 }
 
 // ============================================
@@ -1037,11 +1043,25 @@ function populateSyncFields(data) {
     } else if (data.source_type === 'jira' && data.jira) {
         document.getElementById('jira-url').value = data.jira.url || '';
         document.getElementById('jira-project').value = data.jira.project || '';
-        document.getElementById('jira-token').value = data.jira.token || '';
+        document.getElementById('jira-auth-method').value = data.jira.auth_method || 'cloud';
+        document.getElementById('jira-email').value = data.jira.email || '';
+        if ((data.jira.auth_method || 'cloud') === 'cloud') {
+            document.getElementById('jira-token').value = data.jira.token || '';
+        } else {
+            document.getElementById('jira-token-server').value = data.jira.token || '';
+        }
+        toggleJiraAuth();
     } else if (data.source_type === 'confluence' && data.confluence) {
         document.getElementById('confluence-url').value = data.confluence.url || '';
         document.getElementById('confluence-space').value = data.confluence.space || '';
-        document.getElementById('confluence-token').value = data.confluence.token || '';
+        document.getElementById('confluence-auth-method').value = data.confluence.auth_method || 'cloud';
+        document.getElementById('confluence-email').value = data.confluence.email || '';
+        if ((data.confluence.auth_method || 'cloud') === 'cloud') {
+            document.getElementById('confluence-token').value = data.confluence.token || '';
+        } else {
+            document.getElementById('confluence-token-server').value = data.confluence.token || '';
+        }
+        toggleConfluenceAuth();
     } else if (data.source_type === 'box' && data.box) {
         document.getElementById('box-client-id').value = data.box.client_id || '';
         document.getElementById('box-client-secret').value = data.box.client_secret || '';
@@ -1105,8 +1125,13 @@ function updateSyncStatusDisplay(data) {
         'error': 'Error',
     };
     if (statusValue) {
-        statusValue.textContent = statusLabels[data.sync_status] || data.sync_status;
+        let label = statusLabels[data.sync_status] || data.sync_status;
+        if (data.sync_status === 'error' && data.sync_error) {
+            label = 'Error: ' + data.sync_error;
+        }
+        statusValue.textContent = label;
         statusValue.className = `sync-status-value sync-status-${data.sync_status}`;
+        statusValue.title = data.sync_error || '';
     }
 
     if (lastSynced) {
@@ -1196,16 +1221,28 @@ function gatherSyncConfig() {
             url: document.getElementById('ado-url').value.trim(),
         };
     } else if (sourceType === 'jira') {
+        const jiraMethod = document.getElementById('jira-auth-method').value;
+        const jiraToken = jiraMethod === 'cloud'
+            ? document.getElementById('jira-token').value.trim()
+            : document.getElementById('jira-token-server').value.trim();
         config.jira = {
             url: document.getElementById('jira-url').value.trim(),
             project: document.getElementById('jira-project').value.trim(),
-            token: document.getElementById('jira-token').value.trim(),
+            auth_method: jiraMethod,
+            email: document.getElementById('jira-email').value.trim(),
+            token: jiraToken,
         };
     } else if (sourceType === 'confluence') {
+        const confMethod = document.getElementById('confluence-auth-method').value;
+        const confToken = confMethod === 'cloud'
+            ? document.getElementById('confluence-token').value.trim()
+            : document.getElementById('confluence-token-server').value.trim();
         config.confluence = {
             url: document.getElementById('confluence-url').value.trim(),
             space: document.getElementById('confluence-space').value.trim(),
-            token: document.getElementById('confluence-token').value.trim(),
+            auth_method: confMethod,
+            email: document.getElementById('confluence-email').value.trim(),
+            token: confToken,
         };
     } else if (sourceType === 'box') {
         config.box = {
@@ -1326,6 +1363,18 @@ function toggleGhAuth() {
     const method = document.getElementById('gh-auth-method').value;
     document.getElementById('gh-ssh-fields').style.display = method === 'ssh' ? '' : 'none';
     document.getElementById('gh-token-fields').style.display = method === 'token' ? '' : 'none';
+}
+
+function toggleJiraAuth() {
+    const method = document.getElementById('jira-auth-method').value;
+    document.getElementById('jira-cloud-fields').style.display = method === 'cloud' ? '' : 'none';
+    document.getElementById('jira-server-fields').style.display = method === 'server' ? '' : 'none';
+}
+
+function toggleConfluenceAuth() {
+    const method = document.getElementById('confluence-auth-method').value;
+    document.getElementById('confluence-cloud-fields').style.display = method === 'cloud' ? '' : 'none';
+    document.getElementById('confluence-server-fields').style.display = method === 'server' ? '' : 'none';
 }
 
 function toggleAllBranches() {


### PR DESCRIPTION
## Summary
- Jira and Confluence connectors now support both **Cloud** (API token + Basic auth) and **Server/Data Center** (PAT + Bearer auth) via an auth method dropdown in the UI
- Jira Cloud uses `/rest/api/3/search/jql` endpoint (v2/search returns 410 on newer Cloud instances)
- Confluence Cloud uses `/wiki/rest/api` base path; auto-strips `/wiki` suffix if user includes it in URL
- Sync errors now show as **toast popup notifications** (8s duration) in addition to sidebar status text

## Test plan
- [x] Jira Cloud sync with API token + email (tested against discoverorg.atlassian.net/ZIMOS)
- [x] Confluence Cloud sync with API token + email (tested against discoverorg.atlassian.net)
- [x] Sync error toast appears on auth failure
- [x] Indexing completes after sync
- [ ] Jira Server/DC with PAT (no test instance available)
- [ ] Confluence Server/DC with PAT (no test instance available)