### PR TITLE
Add multi-select dropdowns for Jira projects and Confluence spaces

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,13 +13,13 @@ Useful for teams and individuals who want to:
 
 - File browser with real-time updates
 - Folder creation and file upload
-- Git repository sync and indexing
-- Google Drive integration
-- Jira board sync
+- Remote sync connectors: Git, Google Drive, SharePoint, Azure DevOps, Jira, Confluence, Box
+- Jira/Confluence support for both Cloud and Server/Data Center deployments
 - Per-user folder enable/disable for indexing
 - Automatic document indexing (DOCX, PPTX, XLSX, ODT, ODP, ODS)
-- Vector search with Qdrant
+- Vector search with Qdrant (hybrid semantic + keyword, with time range filtering)
 - MCP server for Claude Code integration
+- Anamnesis: persistent RAG memory for AI assistants (create, retrieve, like/dislike memories)
 - File change detection via content hashing
 - Global file/folder metadata
 - Dark/light theme support
@@ -170,13 +170,20 @@ Add to `~/.claude.json` under `mcpServers` (global) or in your project settings:
 
 | Tool | Description |
 |------|-------------|
-| **`search`** | Hybrid semantic + keyword search across indexed documents |
+| **`search`** | Hybrid semantic + keyword search across indexed documents. Supports `date_start`/`date_end` for time range filtering. |
 | **`list_indexed_folders`** | List all indexed folders with status, file counts, and metadata |
 | **`get_file`** | Get full content of an indexed file |
 | **`get_chunk_range`** | Get a range of chunks from a file, merged with overlaps removed |
 | **`get_file_uri`** | Get a download URI for a file (for use with wget/curl) |
 | **`set_folder_active`** | Set folder visibility for search (requires `X-User-Name` header) |
 | **`get_folder_active_states`** | Get active/inactive state of all folders for current user |
+| **`create_memory`** | Create a persistent memory entry (Anamnesis) |
+| **`get_memory`** | Retrieve a specific memory by ID |
+| **`update_memory`** | Update content of an existing memory |
+| **`delete_memory`** | Delete a memory entry |
+| **`like_memory`** | Upvote a memory (increases relevance) |
+| **`dislike_memory`** | Downvote a memory (decreases relevance) |
+| **`list_memories`** | List all stored memories |
 
 ## Bulk Repository Import
 

--- a/src/voitta/api/routes/sync.py
+++ b/src/voitta/api/routes/sync.py
@@ -475,6 +475,59 @@ async def list_google_drive_folders(
         raise HTTPException(status_code=400, detail=str(e))
 
 
+# --- Atlassian project / space listing ---
+
+
+@router.get("/jira/projects")
+async def list_jira_projects(
+    folder_path: str = Query(...),
+    user: CurrentUser = None,
+    db: DB = None,
+):
+    """List Jira projects accessible with stored credentials."""
+    result = await db.execute(
+        select(FolderSyncSource).where(FolderSyncSource.folder_path == folder_path)
+    )
+    source = result.scalar_one_or_none()
+    if not source or source.source_type != "jira":
+        raise HTTPException(status_code=404, detail="Jira source not found")
+    if not source.jira_token:
+        raise HTTPException(status_code=400, detail="Save Jira credentials first")
+
+    from ...services.sync.jira import list_projects
+
+    try:
+        projects = await list_projects(source)
+        return {"projects": projects}
+    except Exception as e:
+        raise HTTPException(status_code=400, detail=str(e))
+
+
+@router.get("/confluence/spaces")
+async def list_confluence_spaces(
+    folder_path: str = Query(...),
+    user: CurrentUser = None,
+    db: DB = None,
+):
+    """List Confluence spaces accessible with stored credentials."""
+    result = await db.execute(
+        select(FolderSyncSource).where(FolderSyncSource.folder_path == folder_path)
+    )
+    source = result.scalar_one_or_none()
+    if not source or source.source_type != "confluence":
+        raise HTTPException(status_code=404, detail="Confluence source not found")
+    if not source.confluence_token:
+        raise HTTPException(status_code=400, detail="Save Confluence credentials first")
+
+    from ...services.sync.confluence import list_spaces
+
+    try:
+        spaces = await list_spaces(source)
+        return {"spaces": spaces}
+    except Exception as e:
+        raise HTTPException(status_code=400, detail=str(e))
+
+
 # --- CRUD + sync endpoints ---
 
 
@@ -652,18 +705,31 @@ async def upsert_sync_source(
         try:
             base_url, project_key = _parse_jira_url(request.jira.url)
             source.jira_url = base_url
-            # Use parsed project if no explicit project provided
-            source.jira_project = request.jira.project or project_key
         except ValueError:
             source.jira_url = request.jira.url
-            source.jira_project = request.jira.project
+            project_key = ""
+        # Normalize project value: "*" for ALL, or uppercase comma-separated keys
+        project_raw = (request.jira.project or project_key).strip()
+        if project_raw == "*":
+            source.jira_project = "*"
+        else:
+            source.jira_project = ",".join(
+                k.strip().upper() for k in project_raw.split(",") if k.strip()
+            )
     elif request.source_type == "confluence" and request.confluence:
         conf_url = request.confluence.url.rstrip("/")
         # Strip /wiki suffix if user included it (Cloud adds it automatically)
         if conf_url.endswith("/wiki"):
             conf_url = conf_url[:-5]
         source.confluence_url = conf_url
-        source.confluence_space = request.confluence.space.upper()
+        # Normalize space value: "*" for ALL, or uppercase comma-separated keys
+        space_raw = request.confluence.space.strip()
+        if space_raw == "*":
+            source.confluence_space = "*"
+        else:
+            source.confluence_space = ",".join(
+                k.strip().upper() for k in space_raw.split(",") if k.strip()
+            )
         source.confluence_token = request.confluence.token
         source.confluence_auth_method = request.confluence.auth_method or "cloud"
         source.confluence_email = request.confluence.email

--- a/src/voitta/services/sync/confluence.py
+++ b/src/voitta/services/sync/confluence.py
@@ -164,6 +164,54 @@ def _render_page_md(page: dict, attachments: list) -> str:
 
 
 # ---------------------------------------------------------------------------
+# Module-level helpers for API routes
+# ---------------------------------------------------------------------------
+
+
+async def list_spaces(source) -> list[dict]:
+    """List Confluence spaces accessible with the stored credentials.
+
+    Returns a list of dicts with 'key' and 'name' fields.
+    """
+    is_cloud = (source.confluence_auth_method or "cloud") == "cloud"
+
+    if is_cloud:
+        if not source.confluence_email:
+            raise RuntimeError("Confluence Cloud requires an email address")
+        credentials = f"{source.confluence_email}:{source.confluence_token}"
+        b64 = base64.b64encode(credentials.encode()).decode()
+        headers = {"Authorization": f"Basic {b64}", "Content-Type": "application/json"}
+        api_base = f"{source.confluence_url}/wiki/rest/api"
+    else:
+        headers = {"Authorization": f"Bearer {source.confluence_token}", "Content-Type": "application/json"}
+        api_base = f"{source.confluence_url}/rest/api"
+
+    spaces = []
+    async with httpx.AsyncClient(timeout=30.0) as client:
+        start = 0
+        limit = 50
+        while True:
+            resp = await client.get(
+                f"{api_base}/space",
+                params={"start": start, "limit": limit, "type": "global"},
+                headers=headers,
+            )
+            if resp.status_code == 401:
+                raise RuntimeError("Confluence authentication failed. Check your credentials.")
+            if resp.status_code != 200:
+                raise RuntimeError(f"Failed to list spaces ({resp.status_code}): {resp.text[:300]}")
+            data = resp.json()
+            for s in data.get("results", []):
+                spaces.append({"key": s["key"], "name": s.get("name", s["key"])})
+            if len(data.get("results", [])) < limit:
+                break
+            start += limit
+
+    spaces.sort(key=lambda s: s["key"])
+    return spaces
+
+
+# ---------------------------------------------------------------------------
 # Connector
 # ---------------------------------------------------------------------------
 
@@ -254,6 +302,22 @@ class ConfluenceConnector(BaseSyncConnector):
 
     # ---- list_files -------------------------------------------------------
 
+    async def _resolve_space_keys(self, source) -> list[str]:
+        """Resolve the configured space value into a list of space keys."""
+        space_val = (source.confluence_space or "").strip()
+        if not space_val:
+            raise RuntimeError("Confluence space not configured")
+        if space_val == "*":
+            # Fetch all spaces
+            all_spaces = await list_spaces(source)
+            retval = [s["key"] for s in all_spaces]
+            return retval
+        if "," in space_val:
+            retval = [k.strip() for k in space_val.split(",") if k.strip()]
+            return retval
+        retval = [space_val]
+        return retval
+
     async def list_files(self, source) -> list[RemoteFile]:
         if not source.confluence_token:
             raise RuntimeError("Confluence token not configured")
@@ -262,44 +326,52 @@ class ConfluenceConnector(BaseSyncConnector):
         if self._is_cloud(source) and not source.confluence_email:
             raise RuntimeError("Confluence Cloud requires an email address")
 
+        space_keys = await self._resolve_space_keys(source)
+
         files: list[RemoteFile] = []
         headers = self._headers(source)
         base = self._api_base(source)
 
         async with httpx.AsyncClient(timeout=60.0) as client:
-            pages = await self._get_all_pages_in_space(
-                client, headers, base, source.confluence_space
-            )
-
-            # Build map for path resolution
-            page_map = {p["id"]: p for p in pages}
-
-            for page in pages:
-                page_id = page["id"]
-                version = page.get("version", {}).get("number", 1)
-                updated = page.get("version", {}).get("when", "")
-
-                remote_path = f"pages/{self._build_page_path(page, page_map)}"
-
-                # Use version number as content hash for change detection
-                content_hash = hashlib.sha256(f"{version}:{updated}".encode()).hexdigest()
-
-                created_date = page.get("history", {}).get("createdDate", "")
-
-                files.append(
-                    RemoteFile(
-                        remote_path=remote_path,
-                        size=0,
-                        modified_at=updated,
-                        content_hash=content_hash,
-                        created_at=created_date,
-                    )
+            for space_key in space_keys:
+                pages = await self._get_all_pages_in_space(
+                    client, headers, base, space_key
                 )
 
-        logger.info(
-            "Listed %d pages from Confluence space %s",
-            len(files), source.confluence_space
-        )
+                # Build map for path resolution
+                page_map = {p["id"]: p for p in pages}
+
+                # Prefix with space key when syncing multiple spaces
+                prefix = f"{space_key}/" if len(space_keys) > 1 else ""
+
+                for page in pages:
+                    page_id = page["id"]
+                    version = page.get("version", {}).get("number", 1)
+                    updated = page.get("version", {}).get("when", "")
+
+                    remote_path = f"pages/{prefix}{self._build_page_path(page, page_map)}"
+
+                    # Use version number as content hash for change detection
+                    content_hash = hashlib.sha256(f"{version}:{updated}".encode()).hexdigest()
+
+                    created_date = page.get("history", {}).get("createdDate", "")
+
+                    files.append(
+                        RemoteFile(
+                            remote_path=remote_path,
+                            size=0,
+                            modified_at=updated,
+                            content_hash=content_hash,
+                            created_at=created_date,
+                        )
+                    )
+
+                logger.info(
+                    "Listed %d pages from Confluence space %s",
+                    len(files), space_key
+                )
+
+        logger.info("Listed %d total pages from %d Confluence space(s)", len(files), len(space_keys))
         return files
 
     # ---- download_file ----------------------------------------------------

--- a/src/voitta/services/sync/jira.py
+++ b/src/voitta/services/sync/jira.py
@@ -320,6 +320,67 @@ def _render_issue_md(
 
 
 # ---------------------------------------------------------------------------
+# Module-level helpers for API routes
+# ---------------------------------------------------------------------------
+
+
+async def list_projects(source) -> list[dict]:
+    """List Jira projects accessible with the stored credentials.
+
+    Returns a list of dicts with 'key' and 'name' fields.
+    """
+    is_cloud = (source.jira_auth_method or "cloud") == "cloud"
+
+    if is_cloud:
+        if not source.jira_email:
+            raise RuntimeError("Jira Cloud requires an email address")
+        credentials = f"{source.jira_email}:{source.jira_token}"
+        b64 = base64.b64encode(credentials.encode()).decode()
+        headers = {"Authorization": f"Basic {b64}", "Content-Type": "application/json"}
+    else:
+        headers = {"Authorization": f"Bearer {source.jira_token}", "Content-Type": "application/json"}
+
+    base_url = source.jira_url
+
+    projects = []
+    async with httpx.AsyncClient(timeout=30.0) as client:
+        if is_cloud:
+            # Cloud: paginated project search via v3
+            start_at = 0
+            while True:
+                resp = await client.get(
+                    f"{base_url}/rest/api/3/project/search",
+                    params={"startAt": start_at, "maxResults": 50},
+                    headers=headers,
+                )
+                if resp.status_code == 401:
+                    raise RuntimeError("Jira authentication failed. Check your email and API token.")
+                if resp.status_code != 200:
+                    raise RuntimeError(f"Failed to list projects ({resp.status_code}): {resp.text[:300]}")
+                data = resp.json()
+                for p in data.get("values", []):
+                    projects.append({"key": p["key"], "name": p.get("name", p["key"])})
+                if data.get("isLast", True):
+                    break
+                start_at += len(data.get("values", []))
+        else:
+            # Server/DC: simple list via v2
+            resp = await client.get(
+                f"{base_url}/rest/api/2/project",
+                headers=headers,
+            )
+            if resp.status_code == 401:
+                raise RuntimeError("Jira authentication failed. Check your PAT.")
+            if resp.status_code != 200:
+                raise RuntimeError(f"Failed to list projects ({resp.status_code}): {resp.text[:300]}")
+            for p in resp.json():
+                projects.append({"key": p["key"], "name": p.get("name", p["key"])})
+
+    projects.sort(key=lambda p: p["key"])
+    return projects
+
+
+# ---------------------------------------------------------------------------
 # Connector
 # ---------------------------------------------------------------------------
 
@@ -397,10 +458,14 @@ class JiraConnector(BaseSyncConnector):
 
         try:
             async with httpx.AsyncClient(timeout=60.0) as client:
-                # List boards for the project
+                # List boards for the project(s)
+                board_params = {"maxResults": 50}
+                project_val = (source.jira_project or "").strip()
+                if project_val and project_val != "*" and "," not in project_val:
+                    board_params["projectKeyOrId"] = project_val
                 boards_resp = await client.get(
                     f"{agile}/board",
-                    params={"projectKeyOrId": source.jira_project, "maxResults": 50},
+                    params=board_params,
                     headers=headers,
                 )
                 if boards_resp.status_code != 200:
@@ -565,7 +630,20 @@ class JiraConnector(BaseSyncConnector):
         is_cloud = self._is_cloud(source)
 
         async with httpx.AsyncClient(timeout=60.0) as client:
-            jql = f"project = {source.jira_project} ORDER BY updated DESC"
+            project_val = source.jira_project.strip()
+            if project_val == "*":
+                all_projects = await list_projects(source)
+                all_keys = [p["key"] for p in all_projects]
+                if not all_keys:
+                    raise RuntimeError("No Jira projects found")
+                quoted = ', '.join(f'"{k}"' for k in all_keys)
+                jql = f"project IN ({quoted}) ORDER BY updated DESC"
+            elif "," in project_val:
+                keys = [k.strip() for k in project_val.split(",") if k.strip()]
+                quoted = ', '.join(f'"{k}"' for k in keys)
+                jql = f"project IN ({quoted}) ORDER BY updated DESC"
+            else:
+                jql = f'project = "{project_val}" ORDER BY updated DESC'
 
             if is_cloud:
                 # Cloud: use v3 search/jql endpoint (v2/search is deprecated)

--- a/src/voitta/web/templates/browser.html
+++ b/src/voitta/web/templates/browser.html
@@ -318,8 +318,15 @@
                         <input type="text" id="jira-url" class="sync-input" placeholder="https://yourorg.atlassian.net">
                     </div>
                     <div class="form-group-compact">
-                        <label class="form-label-compact">Project Key</label>
-                        <input type="text" id="jira-project" class="sync-input" placeholder="PROJ">
+                        <label class="form-label-compact">Project(s)</label>
+                        <div class="ms-container" id="jira-project-container">
+                            <div class="ms-display" onclick="msToggle('jira-project')">
+                                <span class="ms-text" id="jira-project-text">Select projects...</span>
+                                <span class="ms-arrow">&#9662;</span>
+                            </div>
+                            <div class="ms-dropdown" id="jira-project-dropdown"></div>
+                        </div>
+                        <button type="button" class="btn btn-text btn-sm" id="btn-jira-fetch-projects" onclick="fetchJiraProjects()" title="Fetch projects from Jira" style="margin-top:2px; font-size:11px;">Fetch Projects</button>
                     </div>
                     <div class="form-group-compact">
                         <label class="form-label-compact">Auth Method</label>
@@ -353,8 +360,15 @@
                         <input type="text" id="confluence-url" class="sync-input" placeholder="https://yourorg.atlassian.net (no /wiki)">
                     </div>
                     <div class="form-group-compact">
-                        <label class="form-label-compact">Space Key</label>
-                        <input type="text" id="confluence-space" class="sync-input" placeholder="DAIHUB">
+                        <label class="form-label-compact">Space(s)</label>
+                        <div class="ms-container" id="confluence-space-container">
+                            <div class="ms-display" onclick="msToggle('confluence-space')">
+                                <span class="ms-text" id="confluence-space-text">Select spaces...</span>
+                                <span class="ms-arrow">&#9662;</span>
+                            </div>
+                            <div class="ms-dropdown" id="confluence-space-dropdown"></div>
+                        </div>
+                        <button type="button" class="btn btn-text btn-sm" id="btn-confluence-fetch-spaces" onclick="fetchConfluenceSpaces()" title="Fetch spaces from Confluence" style="margin-top:2px; font-size:11px;">Fetch Spaces</button>
                     </div>
                     <div class="form-group-compact">
                         <label class="form-label-compact">Auth Method</label>

--- a/static/css/styles.css
+++ b/static/css/styles.css
@@ -1295,6 +1295,115 @@ a:hover {
     border-color: var(--color-accent);
 }
 
+/* Custom multi-select dropdown */
+.ms-container {
+    position: relative;
+    width: 100%;
+}
+
+.ms-display {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    width: 100%;
+    padding: var(--spacing-xs) var(--spacing-sm);
+    font-family: inherit;
+    font-size: var(--font-size-sm);
+    color: var(--color-text-primary);
+    background: var(--color-bg-elevated);
+    border: 1px solid var(--color-border);
+    border-radius: var(--radius-sm);
+    cursor: pointer;
+    user-select: none;
+    min-height: 28px;
+    box-sizing: border-box;
+}
+
+.ms-display:hover {
+    border-color: var(--color-accent);
+}
+
+.ms-text {
+    flex: 1;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+    font-size: var(--font-size-xs);
+    color: var(--color-text-secondary);
+}
+
+.ms-text.has-value {
+    color: var(--color-text-primary);
+}
+
+.ms-arrow {
+    font-size: 10px;
+    color: var(--color-text-tertiary);
+    margin-left: 4px;
+    flex-shrink: 0;
+}
+
+.ms-dropdown {
+    display: none;
+    position: absolute;
+    top: 100%;
+    left: 0;
+    right: 0;
+    z-index: 100;
+    max-height: 180px;
+    overflow-y: auto;
+    background: var(--color-bg-elevated);
+    border: 1px solid var(--color-accent);
+    border-top: none;
+    border-radius: 0 0 var(--radius-sm) var(--radius-sm);
+    box-shadow: 0 4px 12px rgba(0, 0, 0, 0.3);
+}
+
+.ms-dropdown.open {
+    display: block;
+}
+
+.ms-option {
+    display: flex;
+    align-items: center;
+    gap: 6px;
+    padding: 5px 8px;
+    font-size: var(--font-size-xs);
+    cursor: pointer;
+    user-select: none;
+}
+
+.ms-option:hover {
+    background: var(--color-bg-hover);
+}
+
+.ms-option input[type="checkbox"] {
+    margin: 0;
+    flex-shrink: 0;
+}
+
+.ms-option.ms-all {
+    border-bottom: 1px solid var(--color-border);
+    font-weight: var(--font-weight-medium);
+}
+
+.ms-option.ms-disabled {
+    opacity: 0.4;
+    pointer-events: none;
+}
+
+.ms-empty {
+    padding: 6px 8px;
+    font-size: var(--font-size-xs);
+    color: var(--color-text-tertiary);
+    font-style: italic;
+}
+
+.ms-container.disabled .ms-display {
+    opacity: 0.5;
+    pointer-events: none;
+}
+
 .sync-fields {
     display: flex;
     flex-direction: column;

--- a/static/js/app.js
+++ b/static/js/app.js
@@ -1042,7 +1042,6 @@ function populateSyncFields(data) {
         updateAdoConnectStatus(data.azure_devops.connected);
     } else if (data.source_type === 'jira' && data.jira) {
         document.getElementById('jira-url').value = data.jira.url || '';
-        document.getElementById('jira-project').value = data.jira.project || '';
         document.getElementById('jira-auth-method').value = data.jira.auth_method || 'cloud';
         document.getElementById('jira-email').value = data.jira.email || '';
         if ((data.jira.auth_method || 'cloud') === 'cloud') {
@@ -1051,9 +1050,16 @@ function populateSyncFields(data) {
             document.getElementById('jira-token-server').value = data.jira.token || '';
         }
         toggleJiraAuth();
+        // Populate project multi-select
+        const savedProject = data.jira.project || '';
+        const projectKeys = savedProject === '*' ? ['*'] : savedProject.split(',').map(k => k.trim()).filter(Boolean);
+        if (savedProject && data.jira.url && data.jira.token) {
+            fetchJiraProjects(projectKeys);
+        } else {
+            msInit('jira-project', [], projectKeys);
+        }
     } else if (data.source_type === 'confluence' && data.confluence) {
         document.getElementById('confluence-url').value = data.confluence.url || '';
-        document.getElementById('confluence-space').value = data.confluence.space || '';
         document.getElementById('confluence-auth-method').value = data.confluence.auth_method || 'cloud';
         document.getElementById('confluence-email').value = data.confluence.email || '';
         if ((data.confluence.auth_method || 'cloud') === 'cloud') {
@@ -1062,6 +1068,14 @@ function populateSyncFields(data) {
             document.getElementById('confluence-token-server').value = data.confluence.token || '';
         }
         toggleConfluenceAuth();
+        // Populate space multi-select
+        const savedSpace = data.confluence.space || '';
+        const spaceKeys = savedSpace === '*' ? ['*'] : savedSpace.split(',').map(k => k.trim()).filter(Boolean);
+        if (savedSpace && data.confluence.url && data.confluence.token) {
+            fetchConfluenceSpaces(spaceKeys);
+        } else {
+            msInit('confluence-space', [], spaceKeys);
+        }
     } else if (data.source_type === 'box' && data.box) {
         document.getElementById('box-client-id').value = data.box.client_id || '';
         document.getElementById('box-client-secret').value = data.box.client_secret || '';
@@ -1069,10 +1083,21 @@ function populateSyncFields(data) {
         updateBoxConnectStatus(data.box.connected);
     }
 
+    // Re-enable all inputs for unlocked sources (clearSyncFields handles most,
+    // but selects need explicit re-enable in case prior folder was locked)
+    if (!locked) {
+        document.querySelectorAll('.sync-fields .sync-select').forEach(el => el.disabled = false);
+        document.querySelectorAll('.sync-input, .sync-textarea').forEach(el => el.disabled = false);
+        msSetDisabled('jira-project', false);
+        msSetDisabled('confluence-space', false);
+    }
+
     // Lock inputs and hide save/remove when folder has synced content
     // Keep the Connect/Reconnect button visible so users can re-consent to new scopes
     if (locked) {
         document.querySelectorAll('.sync-input, .sync-textarea, .sync-fields .sync-select').forEach(el => el.disabled = true);
+        msSetDisabled('jira-project', true);
+        msSetDisabled('confluence-space', true);
         const saveBtn = document.getElementById('btn-sync-save');
         const removeBtn = document.getElementById('btn-sync-remove');
         if (saveBtn) saveBtn.style.display = 'none';
@@ -1094,6 +1119,12 @@ function clearSyncFields() {
         el.value = '';
         el.disabled = false;
     });
+    document.querySelectorAll('.sync-fields .sync-select').forEach(el => {
+        el.disabled = false;
+    });
+    // Reset custom multi-select widgets
+    msReset('jira-project');
+    msReset('confluence-space');
     const actions = document.getElementById('sync-actions');
     if (actions) actions.style.display = 'none';
     const saveBtn = document.getElementById('btn-sync-save');
@@ -1227,7 +1258,7 @@ function gatherSyncConfig() {
             : document.getElementById('jira-token-server').value.trim();
         config.jira = {
             url: document.getElementById('jira-url').value.trim(),
-            project: document.getElementById('jira-project').value.trim(),
+            project: msGetValue('jira-project'),
             auth_method: jiraMethod,
             email: document.getElementById('jira-email').value.trim(),
             token: jiraToken,
@@ -1239,7 +1270,7 @@ function gatherSyncConfig() {
             : document.getElementById('confluence-token-server').value.trim();
         config.confluence = {
             url: document.getElementById('confluence-url').value.trim(),
-            space: document.getElementById('confluence-space').value.trim(),
+            space: msGetValue('confluence-space'),
             auth_method: confMethod,
             email: document.getElementById('confluence-email').value.trim(),
             token: confToken,
@@ -1517,6 +1548,255 @@ async function fetchGoogleDriveFolders(preselectFolder) {
         console.warn('Failed to fetch Google Drive folders:', e.message);
     } finally {
         folderSelect.disabled = false;
+    }
+}
+
+// ---- Custom multi-select checkbox dropdown ----
+
+// Internal state for multi-select widgets
+const _msState = {};
+
+function msInit(id, items, selectedValues) {
+    // items: [{value, label}, ...] -- always prepend ALL
+    _msState[id] = { items: items, selected: new Set(selectedValues || []) };
+    _msRender(id);
+}
+
+function _msRender(id) {
+    const dropdown = document.getElementById(id + '-dropdown');
+    const textEl = document.getElementById(id + '-text');
+    if (!dropdown || !textEl) return;
+
+    const state = _msState[id];
+    if (!state) return;
+
+    dropdown.innerHTML = '';
+    // Close dropdown when re-rendering
+    dropdown.classList.remove('open');
+
+    if (state.items.length === 0) {
+        // No items fetched yet — show hint in dropdown
+        const hint = document.createElement('div');
+        hint.className = 'ms-empty';
+        hint.textContent = 'Click "Fetch" to load options';
+        dropdown.appendChild(hint);
+    } else {
+        // ALL option
+        const allDiv = document.createElement('div');
+        allDiv.className = 'ms-option ms-all';
+        const allCb = document.createElement('input');
+        allCb.type = 'checkbox';
+        allCb.checked = state.selected.has('*');
+        allCb.onchange = () => _msToggleAll(id, allCb.checked);
+        const allLabel = document.createElement('span');
+        allLabel.textContent = '-- ALL --';
+        allDiv.appendChild(allCb);
+        allDiv.appendChild(allLabel);
+        dropdown.appendChild(allDiv);
+
+        // Individual items
+        const allSelected = state.selected.has('*');
+        state.items.forEach(item => {
+            const div = document.createElement('div');
+            div.className = 'ms-option' + (allSelected ? ' ms-disabled' : '');
+            const cb = document.createElement('input');
+            cb.type = 'checkbox';
+            cb.checked = state.selected.has(item.value) || allSelected;
+            cb.disabled = allSelected;
+            cb.onchange = () => _msToggleItem(id, item.value, cb.checked);
+            const label = document.createElement('span');
+            label.textContent = item.label;
+            div.appendChild(cb);
+            div.appendChild(label);
+            dropdown.appendChild(div);
+        });
+    }
+
+    // Update display text
+    _msUpdateText(id);
+}
+
+function _msToggleAll(id, checked) {
+    const state = _msState[id];
+    if (!state) return;
+    if (checked) {
+        state.selected.clear();
+        state.selected.add('*');
+    } else {
+        state.selected.clear();
+    }
+    _msRender(id);
+}
+
+function _msToggleItem(id, value, checked) {
+    const state = _msState[id];
+    if (!state) return;
+    state.selected.delete('*');
+    if (checked) {
+        state.selected.add(value);
+    } else {
+        state.selected.delete(value);
+    }
+    // If all individual items are selected, switch to ALL
+    if (state.items.length > 0 && state.selected.size === state.items.length) {
+        state.selected.clear();
+        state.selected.add('*');
+    }
+    _msRender(id);
+}
+
+function _msUpdateText(id) {
+    const textEl = document.getElementById(id + '-text');
+    const state = _msState[id];
+    if (!textEl || !state) return;
+
+    if (state.selected.has('*')) {
+        textEl.textContent = 'All (syncs all current & future)';
+        textEl.classList.add('has-value');
+    } else if (state.selected.size === 0) {
+        if (state.items.length === 0) {
+            textEl.textContent = 'Click Fetch to load';
+        } else {
+            textEl.textContent = 'None selected';
+        }
+        textEl.classList.remove('has-value');
+    } else if (state.selected.size <= 3) {
+        textEl.textContent = Array.from(state.selected).join(', ');
+        textEl.classList.add('has-value');
+    } else {
+        textEl.textContent = state.selected.size + ' selected';
+        textEl.classList.add('has-value');
+    }
+}
+
+function msToggle(id) {
+    const dropdown = document.getElementById(id + '-dropdown');
+    if (!dropdown) return;
+    const isOpen = dropdown.classList.contains('open');
+    // Close all other dropdowns first
+    document.querySelectorAll('.ms-dropdown.open').forEach(d => d.classList.remove('open'));
+    if (!isOpen) {
+        dropdown.classList.add('open');
+    }
+}
+
+function msGetValue(id) {
+    const state = _msState[id];
+    if (!state) return '';
+    if (state.selected.has('*')) return '*';
+    return Array.from(state.selected).join(',');
+}
+
+function msSetValue(id, csvValue) {
+    const state = _msState[id];
+    if (!state) {
+        // State not yet initialized, just init with the value
+        _msState[id] = { items: [], selected: new Set() };
+    }
+    const s = _msState[id];
+    s.selected.clear();
+    if (!csvValue) return;
+    if (csvValue === '*') {
+        s.selected.add('*');
+    } else {
+        csvValue.split(',').forEach(k => {
+            const trimmed = k.trim();
+            if (trimmed) s.selected.add(trimmed);
+        });
+    }
+    _msRender(id);
+}
+
+function msReset(id) {
+    _msState[id] = { items: [], selected: new Set() };
+    const dropdown = document.getElementById(id + '-dropdown');
+    if (dropdown) {
+        dropdown.innerHTML = '';
+        dropdown.classList.remove('open');
+    }
+    const textEl = document.getElementById(id + '-text');
+    if (textEl) {
+        textEl.textContent = 'Click Fetch to load';
+        textEl.classList.remove('has-value');
+    }
+    msSetDisabled(id, false);
+}
+
+function msSetDisabled(id, disabled) {
+    const container = document.getElementById(id + '-container');
+    if (container) {
+        if (disabled) {
+            container.classList.add('disabled');
+        } else {
+            container.classList.remove('disabled');
+        }
+    }
+}
+
+// Close dropdowns when clicking outside
+document.addEventListener('click', (e) => {
+    if (!e.target.closest('.ms-container')) {
+        document.querySelectorAll('.ms-dropdown.open').forEach(d => d.classList.remove('open'));
+    }
+});
+
+async function fetchJiraProjects(preselectValues) {
+    const targetPath = selectedPath || currentPath;
+    if (!targetPath) return;
+
+    const savedValues = preselectValues || Array.from(_msState['jira-project']?.selected || []);
+    const textEl = document.getElementById('jira-project-text');
+    if (textEl) textEl.textContent = 'Loading...';
+    msSetDisabled('jira-project', true);
+
+    try {
+        const resp = await fetch(`/api/sync/jira/projects?folder_path=${encodeURIComponent(targetPath)}`);
+        if (!resp.ok) {
+            const err = await resp.json().catch(() => ({}));
+            throw new Error(err.detail || resp.statusText);
+        }
+        const data = await resp.json();
+        const projects = data.projects || [];
+
+        const items = projects.map(p => ({ value: p.key, label: `${p.key} - ${p.name}` }));
+        msInit('jira-project', items, savedValues);
+        showToast(`Found ${projects.length} project(s)`, 'success');
+    } catch (e) {
+        msInit('jira-project', [], savedValues);
+        showToast('Failed to fetch projects: ' + e.message, 'error');
+        console.warn('Failed to fetch Jira projects:', e.message);
+    } finally {
+        msSetDisabled('jira-project', false);
+    }
+}
+
+async function fetchConfluenceSpaces(preselectValues) {
+    const targetPath = selectedPath || currentPath;
+    if (!targetPath) return;
+
+    const savedValues = preselectValues || Array.from(_msState['confluence-space']?.selected || []);
+    const textEl = document.getElementById('confluence-space-text');
+    if (textEl) textEl.textContent = 'Loading...';
+    msSetDisabled('confluence-space', true);
+
+    try {
+        const resp = await fetch(`/api/sync/confluence/spaces?folder_path=${encodeURIComponent(targetPath)}`);
+        if (!resp.ok) {
+            const err = await resp.json().catch(() => ({}));
+            throw new Error(err.detail || resp.statusText);
+        }
+        const data = await resp.json();
+        const spaces = data.spaces || [];
+
+        const items = spaces.map(s => ({ value: s.key, label: `${s.key} - ${s.name}` }));
+        msInit('confluence-space', items, savedValues);
+        showToast(`Found ${spaces.length} space(s)`, 'success');
+    } catch (e) {
+        msInit('confluence-space', [], savedValues);
+        showToast('Failed to fetch spaces: ' + e.message, 'error');
+        console.warn('Failed to fetch Confluence spaces:', e.message);
+    } finally {
+        msSetDisabled('confluence-space', false);
     }
 }
 


### PR DESCRIPTION
## Summary

- Add API endpoints to list Jira projects and Confluence spaces from stored credentials
- Replace text inputs with custom checkbox dropdown widgets supporting multi-select and "--ALL--" option
- ALL selection is dynamic (resolves at sync time, includes future projects/spaces)
- Quote JQL project keys to handle reserved words (e.g., "IS")
- Fix auth method dropdown not responding after viewing locked folders
- Fix dropdown transparency caused by undefined CSS custom properties
- Update README with Anamnesis, time range search, and additional connectors

## Test plan

- [x] Confluence single-space sync works
- [x] Confluence ALL spaces sync in progress (23k+ files downloading)
- [x] Jira ALL projects sync in progress
- [ ] Verify Jira single-project sync still works
- [ ] Verify auth method dropdown toggles between Cloud and Server
- [ ] Verify ALL greys out individual items, unchecking ALL re-enables them