### PR TITLE
Add AWS Glue Data Catalog as sync data source

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,6 +38,8 @@ dependencies = [
     "httpx>=0.26.0",
     "google-api-python-client>=2.100.0",
     "google-auth>=2.23.0",
+    # AWS
+    "boto3>=1.28.0",
 ]
 
 [project.optional-dependencies]

--- a/requirements.txt
+++ b/requirements.txt
@@ -25,5 +25,8 @@ fastembed>=0.7.0
 tqdm>=4.60.0
 torch>=2.0.0
 
+# AWS
+boto3>=1.28.0
+
 # MCP server
 fastmcp>=0.4.0

--- a/src/voitta/api/routes/sync.py
+++ b/src/voitta/api/routes/sync.py
@@ -83,6 +83,16 @@ class BoxConfig(BaseModel):
     connected: bool = False
 
 
+class GlueCatalogConfig(BaseModel):
+    region: str = ""
+    auth_method: str = "profile"  # "profile" or "keys"
+    profile: str = ""
+    access_key_id: str = ""
+    secret_access_key: str = ""
+    catalog_id: str = ""
+    databases: str = ""  # comma-separated or "*" for all
+
+
 class UpsertSyncSourceRequest(BaseModel):
     source_type: str
     sharepoint: SharePointConfig | None = None
@@ -92,6 +102,7 @@ class UpsertSyncSourceRequest(BaseModel):
     jira: JiraConfig | None = None
     confluence: ConfluenceConfig | None = None
     box: BoxConfig | None = None
+    glue_catalog: GlueCatalogConfig | None = None
 
 
 class SyncSourceResponse(BaseModel):
@@ -107,6 +118,7 @@ class SyncSourceResponse(BaseModel):
     jira: JiraConfig | None = None
     confluence: ConfluenceConfig | None = None
     box: BoxConfig | None = None
+    glue_catalog: GlueCatalogConfig | None = None
 
 
 class SyncStatusResponse(BaseModel):
@@ -195,6 +207,17 @@ def _to_response(source: FolderSyncSource) -> SyncSourceResponse:
             folder_id=source.box_folder_id or "",
             connected=bool(source.box_refresh_token),
         )
+    elif source.source_type == "glue_catalog":
+        auth_method = "keys" if source.glue_access_key_id else "profile"
+        glue_catalog = GlueCatalogConfig(
+            region=source.glue_region or "",
+            auth_method=auth_method,
+            profile=source.glue_profile or "",
+            access_key_id=source.glue_access_key_id or "",
+            secret_access_key=source.glue_secret_access_key or "",
+            catalog_id=source.glue_catalog_id or "",
+            databases=source.glue_databases or "",
+        )
 
     return SyncSourceResponse(
         folder_path=source.folder_path,
@@ -209,6 +232,7 @@ def _to_response(source: FolderSyncSource) -> SyncSourceResponse:
         jira=jira,
         confluence=confluence,
         box=box,
+        glue_catalog=glue_catalog if source.source_type == "glue_catalog" else None,
     )
 
 
@@ -626,7 +650,7 @@ async def upsert_sync_source(
             detail="Sync can only be configured on empty folders",
         )
 
-    if request.source_type not in ("sharepoint", "google_drive", "github", "azure_devops", "jira", "confluence", "box"):
+    if request.source_type not in ("sharepoint", "google_drive", "github", "azure_devops", "jira", "confluence", "box", "glue_catalog"):
         raise HTTPException(
             status_code=status.HTTP_400_BAD_REQUEST,
             detail=f"Unknown source type: {request.source_type}",
@@ -654,6 +678,8 @@ async def upsert_sync_source(
         "jira_url", "jira_project", "jira_token", "jira_auth_method", "jira_email",
         "confluence_url", "confluence_space", "confluence_token", "confluence_auth_method", "confluence_email",
         "box_client_id", "box_client_secret", "box_folder_id",
+        "glue_region", "glue_profile", "glue_access_key_id", "glue_secret_access_key",
+        "glue_catalog_id", "glue_databases",
     ):
         setattr(source, field, None)
     # Clear OAuth tokens only when source type changes (they are set by the
@@ -745,6 +771,18 @@ async def upsert_sync_source(
             if m:
                 folder_id = m.group(1)
         source.box_folder_id = folder_id
+    elif request.source_type == "glue_catalog" and request.glue_catalog:
+        source.glue_region = request.glue_catalog.region
+        source.glue_catalog_id = request.glue_catalog.catalog_id or None
+        source.glue_databases = request.glue_catalog.databases or None
+        if request.glue_catalog.auth_method == "keys":
+            source.glue_access_key_id = request.glue_catalog.access_key_id
+            source.glue_secret_access_key = request.glue_catalog.secret_access_key
+            source.glue_profile = None
+        else:
+            source.glue_profile = request.glue_catalog.profile or None
+            source.glue_access_key_id = None
+            source.glue_secret_access_key = None
 
     await db.flush()
     return _to_response(source)

--- a/src/voitta/db/models.py
+++ b/src/voitta/db/models.py
@@ -195,6 +195,14 @@ class FolderSyncSource(Base):
     box_folder_id: Mapped[str | None] = mapped_column(String(255), nullable=True)
     box_refresh_token: Mapped[str | None] = mapped_column(Text, nullable=True)
 
+    # AWS Glue Catalog
+    glue_region: Mapped[str | None] = mapped_column(String(50), nullable=True)
+    glue_profile: Mapped[str | None] = mapped_column(String(255), nullable=True)
+    glue_access_key_id: Mapped[str | None] = mapped_column(String(255), nullable=True)
+    glue_secret_access_key: Mapped[str | None] = mapped_column(String(500), nullable=True)
+    glue_catalog_id: Mapped[str | None] = mapped_column(String(255), nullable=True)
+    glue_databases: Mapped[str | None] = mapped_column(String(1000), nullable=True)
+
     # Sync status tracking
     sync_status: Mapped[str] = mapped_column(String(20), default="idle")
     sync_error: Mapped[str | None] = mapped_column(Text, nullable=True)

--- a/src/voitta/services/sync/__init__.py
+++ b/src/voitta/services/sync/__init__.py
@@ -5,6 +5,7 @@ from .base import BaseSyncConnector
 from .box import BoxConnector
 from .confluence import ConfluenceConnector
 from .github import GitHubConnector
+from .glue_catalog import GlueCatalogConnector
 from .google_drive import GoogleDriveConnector
 from .jira import JiraConnector
 from .sharepoint import SharePointConnector
@@ -17,6 +18,7 @@ _connectors: dict[str, BaseSyncConnector] = {
     "jira": JiraConnector(),
     "confluence": ConfluenceConnector(),
     "box": BoxConnector(),
+    "glue_catalog": GlueCatalogConnector(),
 }
 
 

--- a/src/voitta/services/sync/glue_catalog.py
+++ b/src/voitta/services/sync/glue_catalog.py
@@ -1,0 +1,274 @@
+"""AWS Glue Data Catalog sync connector - indexes schema metadata (databases, tables, columns)."""
+
+import hashlib
+import logging
+from pathlib import Path
+
+import boto3
+
+from .base import BaseSyncConnector, RemoteFile
+
+logger = logging.getLogger(__name__)
+
+
+def _get_glue_client(source):
+    """Build a boto3 Glue client from the sync source config."""
+    kwargs = {}
+    if source.glue_region:
+        kwargs["region_name"] = source.glue_region
+
+    if source.glue_access_key_id and source.glue_secret_access_key:
+        session = boto3.Session(
+            aws_access_key_id=source.glue_access_key_id,
+            aws_secret_access_key=source.glue_secret_access_key,
+            **kwargs,
+        )
+    elif source.glue_profile:
+        session = boto3.Session(profile_name=source.glue_profile, **kwargs)
+    else:
+        session = boto3.Session(**kwargs)
+
+    retval = session.client("glue")
+    return retval
+
+
+def _get_databases(client, catalog_id: str | None, db_filter: str | None) -> list[dict]:
+    """Fetch databases from Glue, optionally filtered."""
+    kwargs = {}
+    if catalog_id:
+        kwargs["CatalogId"] = catalog_id
+
+    databases = []
+    paginator = client.get_paginator("get_databases")
+    for page in paginator.paginate(**kwargs):
+        for db in page.get("DatabaseList", []):
+            databases.append(db)
+
+    if db_filter and db_filter != "*":
+        allowed = {name.strip().lower() for name in db_filter.split(",") if name.strip()}
+        databases = [db for db in databases if db["Name"].lower() in allowed]
+
+    return databases
+
+
+def _get_tables(client, database_name: str, catalog_id: str | None) -> list[dict]:
+    """Fetch all tables for a database."""
+    kwargs = {"DatabaseName": database_name}
+    if catalog_id:
+        kwargs["CatalogId"] = catalog_id
+
+    tables = []
+    paginator = client.get_paginator("get_tables")
+    for page in paginator.paginate(**kwargs):
+        for table in page.get("TableList", []):
+            tables.append(table)
+
+    return tables
+
+
+def _render_database_md(db: dict, tables: list[dict]) -> str:
+    """Render a database summary as markdown."""
+    name = db["Name"]
+    description = db.get("Description", "")
+    location = db.get("LocationUri", "")
+    params = db.get("Parameters", {})
+
+    lines = [f"# Database: {name}\n"]
+
+    if description:
+        lines.append(f"{description}\n")
+
+    lines.append("| Field | Value |")
+    lines.append("|---|---|")
+    lines.append(f"| Name | {name} |")
+    if location:
+        lines.append(f"| Location | {location} |")
+    if params:
+        for k, v in params.items():
+            lines.append(f"| {k} | {v} |")
+    lines.append(f"| Table Count | {len(tables)} |")
+    lines.append("")
+
+    if tables:
+        lines.append("## Tables\n")
+        lines.append("| Table | Type | Columns | Partition Keys |")
+        lines.append("|---|---|---|---|")
+        for t in sorted(tables, key=lambda t: t["Name"]):
+            tname = t["Name"]
+            ttype = t.get("TableType", "")
+            cols = t.get("StorageDescriptor", {}).get("Columns", [])
+            pkeys = t.get("PartitionKeys", [])
+            lines.append(f"| {tname} | {ttype} | {len(cols)} | {len(pkeys)} |")
+        lines.append("")
+
+    retval = "\n".join(lines)
+    return retval
+
+
+def _render_table_md(table: dict, database_name: str) -> str:
+    """Render a single table's metadata as markdown."""
+    name = table["Name"]
+    description = table.get("Description", "")
+    table_type = table.get("TableType", "")
+    create_time = table.get("CreateTime", "")
+    update_time = table.get("UpdateTime", "")
+    owner = table.get("Owner", "")
+    params = table.get("Parameters", {})
+    sd = table.get("StorageDescriptor", {})
+    columns = sd.get("Columns", [])
+    location = sd.get("Location", "")
+    input_format = sd.get("InputFormat", "")
+    output_format = sd.get("OutputFormat", "")
+    serde_info = sd.get("SerdeInfo", {})
+    serde_lib = serde_info.get("SerializationLibrary", "")
+    serde_params = serde_info.get("Parameters", {})
+    partition_keys = table.get("PartitionKeys", [])
+
+    lines = [f"# Table: {database_name}.{name}\n"]
+
+    if description:
+        lines.append(f"{description}\n")
+
+    lines.append("| Field | Value |")
+    lines.append("|---|---|")
+    lines.append(f"| Database | {database_name} |")
+    lines.append(f"| Table | {name} |")
+    if table_type:
+        lines.append(f"| Type | {table_type} |")
+    if owner:
+        lines.append(f"| Owner | {owner} |")
+    if location:
+        lines.append(f"| Location | {location} |")
+    if input_format:
+        lines.append(f"| Input Format | {input_format} |")
+    if output_format:
+        lines.append(f"| Output Format | {output_format} |")
+    if serde_lib:
+        lines.append(f"| SerDe | {serde_lib} |")
+    if create_time:
+        lines.append(f"| Created | {create_time} |")
+    if update_time:
+        lines.append(f"| Updated | {update_time} |")
+    lines.append("")
+
+    # Columns
+    if columns:
+        lines.append("## Columns\n")
+        lines.append("| # | Name | Type | Comment |")
+        lines.append("|---|---|---|---|")
+        for i, col in enumerate(columns, 1):
+            cname = col.get("Name", "")
+            ctype = col.get("Type", "")
+            ccomment = col.get("Comment", "")
+            lines.append(f"| {i} | {cname} | {ctype} | {ccomment} |")
+        lines.append("")
+
+    # Partition keys
+    if partition_keys:
+        lines.append("## Partition Keys\n")
+        lines.append("| # | Name | Type | Comment |")
+        lines.append("|---|---|---|---|")
+        for i, pk in enumerate(partition_keys, 1):
+            pname = pk.get("Name", "")
+            ptype = pk.get("Type", "")
+            pcomment = pk.get("Comment", "")
+            lines.append(f"| {i} | {pname} | {ptype} | {pcomment} |")
+        lines.append("")
+
+    # SerDe parameters
+    if serde_params:
+        lines.append("## SerDe Parameters\n")
+        lines.append("| Key | Value |")
+        lines.append("|---|---|")
+        for k, v in sorted(serde_params.items()):
+            lines.append(f"| {k} | {v} |")
+        lines.append("")
+
+    # Table parameters
+    if params:
+        lines.append("## Table Parameters\n")
+        lines.append("| Key | Value |")
+        lines.append("|---|---|")
+        for k, v in sorted(params.items()):
+            lines.append(f"| {k} | {v} |")
+        lines.append("")
+
+    retval = "\n".join(lines)
+    return retval
+
+
+class GlueCatalogConnector(BaseSyncConnector):
+
+    async def list_files(self, source) -> list[RemoteFile]:
+        if not source.glue_region:
+            raise RuntimeError("AWS region not configured")
+
+        client = _get_glue_client(source)
+        catalog_id = source.glue_catalog_id or None
+        db_filter = source.glue_databases or None
+
+        databases = _get_databases(client, catalog_id, db_filter)
+        files: list[RemoteFile] = []
+
+        for db in databases:
+            db_name = db["Name"]
+            tables = _get_tables(client, db_name, catalog_id)
+
+            # Database summary file
+            db_hash = hashlib.sha256(
+                str(len(tables)).encode() + db_name.encode()
+            ).hexdigest()
+            files.append(RemoteFile(
+                remote_path=f"databases/{db_name}/_database.md",
+                size=0,
+                modified_at="",
+                content_hash=db_hash,
+            ))
+
+            # Per-table files
+            for table in tables:
+                table_name = table["Name"]
+                update_time = str(table.get("UpdateTime", ""))
+                content_hash = hashlib.sha256(update_time.encode()).hexdigest()
+                files.append(RemoteFile(
+                    remote_path=f"databases/{db_name}/{table_name}.md",
+                    size=0,
+                    modified_at=update_time,
+                    content_hash=content_hash,
+                ))
+
+        logger.info("Listed %d files from Glue catalog (%d databases)", len(files), len(databases))
+        return files
+
+    async def download_file(self, source, remote_path: str, local_path: Path) -> None:
+        client = _get_glue_client(source)
+        catalog_id = source.glue_catalog_id or None
+
+        parts = remote_path.split("/")
+        # Expected: databases/{db_name}/_database.md or databases/{db_name}/{table}.md
+        if len(parts) < 3 or parts[0] != "databases":
+            raise RuntimeError(f"Cannot parse path: {remote_path}")
+
+        db_name = parts[1]
+        filename = parts[2]
+
+        if filename == "_database.md":
+            # Database summary
+            kwargs = {"Name": db_name}
+            if catalog_id:
+                kwargs["CatalogId"] = catalog_id
+            resp = client.get_database(**kwargs)
+            db = resp["Database"]
+            tables = _get_tables(client, db_name, catalog_id)
+            content = _render_database_md(db, tables)
+        else:
+            # Table file
+            table_name = filename.replace(".md", "")
+            kwargs = {"DatabaseName": db_name, "Name": table_name}
+            if catalog_id:
+                kwargs["CatalogId"] = catalog_id
+            resp = client.get_table(**kwargs)
+            table = resp["Table"]
+            content = _render_table_md(table, db_name)
+
+        local_path.write_text(content, encoding="utf-8")

--- a/src/voitta/web/templates/browser.html
+++ b/src/voitta/web/templates/browser.html
@@ -158,6 +158,7 @@
                         <option value="jira">Jira</option>
                         <option value="confluence">Confluence</option>
                         <option value="box">Box</option>
+                        <option value="glue_catalog">AWS Glue Catalog</option>
                     </select>
                 </div>
 
@@ -419,6 +420,65 @@
                             Connect
                         </button>
                         <span class="sp-connect-status" id="box-connect-status"></span>
+                    </div>
+                </div>
+
+                <!-- AWS Glue Catalog Fields -->
+                <div id="sync-fields-glue_catalog" class="sync-fields" style="display: none;">
+                    <div class="sync-fields-header">
+                        <button type="button" class="info-icon-btn" onclick="showGlueHelp()" title="AWS Glue Catalog setup info">
+                            <svg viewBox="0 0 20 20" fill="currentColor" width="16" height="16">
+                                <circle cx="10" cy="10" r="9" fill="none" stroke="currentColor" stroke-width="1.5"/>
+                                <text x="10" y="14.5" text-anchor="middle" font-size="12" font-weight="600" fill="currentColor">i</text>
+                            </svg>
+                        </button>
+                    </div>
+                    <div class="form-group-compact">
+                        <label class="form-label-compact">Region</label>
+                        <select id="glue-region" class="sync-select">
+                            <option value="">Select region...</option>
+                            <option value="us-east-1">us-east-1 (N. Virginia)</option>
+                            <option value="us-east-2">us-east-2 (Ohio)</option>
+                            <option value="us-west-1">us-west-1 (N. California)</option>
+                            <option value="us-west-2">us-west-2 (Oregon)</option>
+                            <option value="eu-west-1">eu-west-1 (Ireland)</option>
+                            <option value="eu-west-2">eu-west-2 (London)</option>
+                            <option value="eu-central-1">eu-central-1 (Frankfurt)</option>
+                            <option value="ap-northeast-1">ap-northeast-1 (Tokyo)</option>
+                            <option value="ap-southeast-1">ap-southeast-1 (Singapore)</option>
+                            <option value="ap-southeast-2">ap-southeast-2 (Sydney)</option>
+                        </select>
+                    </div>
+                    <div class="form-group-compact">
+                        <label class="form-label-compact">Auth Method</label>
+                        <select id="glue-auth-method" class="sync-select" onchange="toggleGlueAuth()">
+                            <option value="profile">AWS Profile</option>
+                            <option value="keys">Access Keys</option>
+                        </select>
+                    </div>
+                    <div id="glue-profile-fields">
+                        <div class="form-group-compact">
+                            <label class="form-label-compact">Profile Name</label>
+                            <input type="text" id="glue-profile" class="sync-input" placeholder="default">
+                        </div>
+                    </div>
+                    <div id="glue-keys-fields" style="display: none;">
+                        <div class="form-group-compact">
+                            <label class="form-label-compact">Access Key ID</label>
+                            <input type="text" id="glue-access-key-id" class="sync-input" placeholder="AKIA...">
+                        </div>
+                        <div class="form-group-compact">
+                            <label class="form-label-compact">Secret Access Key</label>
+                            <input type="password" id="glue-secret-access-key" class="sync-input" placeholder="Secret access key">
+                        </div>
+                    </div>
+                    <div class="form-group-compact">
+                        <label class="form-label-compact">Catalog ID</label>
+                        <input type="text" id="glue-catalog-id" class="sync-input" placeholder="Optional (defaults to account ID)">
+                    </div>
+                    <div class="form-group-compact">
+                        <label class="form-label-compact">Databases</label>
+                        <input type="text" id="glue-databases" class="sync-input" placeholder="db1, db2 or * for all">
                     </div>
                 </div>
 

--- a/static/js/app.js
+++ b/static/js/app.js
@@ -1081,6 +1081,15 @@ function populateSyncFields(data) {
         document.getElementById('box-client-secret').value = data.box.client_secret || '';
         document.getElementById('box-folder-id').value = data.box.folder_id || '';
         updateBoxConnectStatus(data.box.connected);
+    } else if (data.source_type === 'glue_catalog' && data.glue_catalog) {
+        document.getElementById('glue-region').value = data.glue_catalog.region || '';
+        document.getElementById('glue-auth-method').value = data.glue_catalog.auth_method || 'profile';
+        document.getElementById('glue-profile').value = data.glue_catalog.profile || '';
+        document.getElementById('glue-access-key-id').value = data.glue_catalog.access_key_id || '';
+        document.getElementById('glue-secret-access-key').value = data.glue_catalog.secret_access_key || '';
+        document.getElementById('glue-catalog-id').value = data.glue_catalog.catalog_id || '';
+        document.getElementById('glue-databases').value = data.glue_catalog.databases || '';
+        toggleGlueAuth();
     }
 
     // Re-enable all inputs for unlocked sources (clearSyncFields handles most,
@@ -1281,6 +1290,17 @@ function gatherSyncConfig() {
             client_secret: document.getElementById('box-client-secret').value.trim(),
             folder_id: document.getElementById('box-folder-id').value.trim(),
         };
+    } else if (sourceType === 'glue_catalog') {
+        const glueMethod = document.getElementById('glue-auth-method').value;
+        config.glue_catalog = {
+            region: document.getElementById('glue-region').value,
+            auth_method: glueMethod,
+            profile: document.getElementById('glue-profile').value.trim(),
+            access_key_id: document.getElementById('glue-access-key-id').value.trim(),
+            secret_access_key: document.getElementById('glue-secret-access-key').value.trim(),
+            catalog_id: document.getElementById('glue-catalog-id').value.trim(),
+            databases: document.getElementById('glue-databases').value.trim(),
+        };
     }
 
     return config;
@@ -1406,6 +1426,21 @@ function toggleConfluenceAuth() {
     const method = document.getElementById('confluence-auth-method').value;
     document.getElementById('confluence-cloud-fields').style.display = method === 'cloud' ? '' : 'none';
     document.getElementById('confluence-server-fields').style.display = method === 'server' ? '' : 'none';
+}
+
+function toggleGlueAuth() {
+    const method = document.getElementById('glue-auth-method').value;
+    document.getElementById('glue-profile-fields').style.display = method === 'profile' ? '' : 'none';
+    document.getElementById('glue-keys-fields').style.display = method === 'keys' ? '' : 'none';
+}
+
+function showGlueHelp() {
+    showToast(
+        'Indexes schema metadata (databases, tables, columns) from AWS Glue Data Catalog. ' +
+        'Use "Profile" for local dev (~/.aws/credentials) or "Access Keys" for Docker deployments. ' +
+        'Leave Databases empty or use * for all databases, or list specific ones separated by commas.',
+        'info',
+    );
 }
 
 function toggleAllBranches() {


### PR DESCRIPTION
## Summary

- Adds AWS Glue Data Catalog as a new sync connector that indexes schema metadata (databases, tables, columns, partition keys) as markdown for RAG indexing
- Supports dual auth: AWS Profile (local dev) and explicit Access Keys (Docker)
- Tested end-to-end against live AWS account (38 databases) and in Docker

## Changes

| File | Change |
|------|--------|
| `src/voitta/services/sync/glue_catalog.py` | New connector with paginated Glue API, markdown rendering |
| `src/voitta/db/models.py` | 6 new `glue_*` columns on `FolderSyncSource` |
| `src/voitta/api/routes/sync.py` | `GlueCatalogConfig` model, upsert/response handling |
| `src/voitta/services/sync/__init__.py` | Register `GlueCatalogConnector` |
| `src/voitta/web/templates/browser.html` | UI: region dropdown, auth toggle, config fields |
| `static/js/app.js` | JS: field population, config gathering, auth toggle, help toast |
| `pyproject.toml` | `boto3>=1.28.0` dependency |
| `requirements.txt` | `boto3>=1.28.0` dependency |

## Test plan

- [ ] Configure a Glue Catalog source via UI with Profile auth, sync, verify markdown files created
- [ ] Configure with Access Keys auth, sync, verify
- [ ] Filter to specific databases, verify only those are indexed
- [ ] Docker build and run, verify Glue sync works with Access Keys
- [ ] Search indexed Glue metadata via RAG search