### PR TITLE
Add Claude Code plugin and session history import

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -68,3 +68,4 @@ scripts/import_repos.json
 CLAUDE.md
 docker-compose.override.yml
 .gitnexus
+.handoffs/

--- a/README.md
+++ b/README.md
@@ -22,8 +22,10 @@ Useful for teams and individuals who want to:
 - [Configuration](#configuration)
   - [Authentication](#authentication)
 - [MCP Server (for Claude Code integration)](#mcp-server-for-claude-code-integration)
-  - [Claude Code Configuration](#claude-code-configuration)
+  - [Claude Code Plugin (automated setup)](#claude-code-plugin-automated-setup)
+  - [Manual Claude Code Configuration](#manual-claude-code-configuration)
   - [Available MCP Tools](#available-mcp-tools)
+  - [Importing Claude Code Session History](#importing-claude-code-session-history)
 - [Concepts](#concepts)
   - [Projects](#projects)
   - [Toggle Switches](#toggle-switches)
@@ -96,7 +98,7 @@ pip install "transformers>=4.36.0,<5.0.0"
 
 ### Option A: Docker (recommended)
 
-Starts both voitta-rag and Qdrant with persistent storage via Docker Compose:
+Runs both voitta-rag and Qdrant in containers. No Python installation needed on the host. The web UI is at port **58000**, the MCP endpoint at `/mcp/mcp` on the same port.
 
 ```bash
 cp .env.example .env
@@ -140,21 +142,25 @@ Note: symlinks inside mounted volumes won't work -- Docker doesn't resolve symli
 
 ### Option B: Local development
 
+Runs voitta-rag directly with Python on your machine. Requires Python 3.11+ (see [Prerequisites](#prerequisites)). Qdrant still runs in Docker. The web UI is at port **8000**, the MCP endpoint at `/mcp/mcp` on the same port.
+
 ```bash
-# Start Qdrant
+# Start Qdrant (vector database)
 mkdir -p qdrant_storage
 docker run -d --name qdrant \
   -p 6333:6333 -p 6334:6334 \
   -v $(pwd)/qdrant_storage:/qdrant/storage \
   qdrant/qdrant
 
-# Install and run
+# Install Python dependencies and run
 make install
 cp .env.example .env
 make run
 ```
 
 Open http://localhost:8000 in your browser.
+
+**Key difference from Docker mode:** In local mode, voitta-rag has direct filesystem access — no volume mounts needed. Set `VOITTA_ROOT_PATH` in `.env` to the directory where indexed data should be stored.
 
 ## Configuration
 
@@ -206,7 +212,24 @@ The MCP server validates tokens independently via `X-Auth-Token-Microsoft` and `
 
 The MCP server runs embedded in the main app (no separate process needed) and exposes RAG capabilities via the [MCP protocol](https://modelcontextprotocol.io/).
 
-### Claude Code Configuration
+### Claude Code Plugin (automated setup)
+
+The fastest way to connect Claude Code to voitta-rag:
+
+```bash
+# Docker mode (port 58000)
+bash claude-plugin/setup.sh --docker
+
+# Local mode (port 8000)
+bash claude-plugin/setup.sh
+
+# With session memory hook (saves a session summary on exit)
+bash claude-plugin/setup.sh --docker --with-hook
+```
+
+The plugin configures the MCP server in `~/.claude.json` and optionally installs a `Stop` hook that prompts Claude to save a session summary as a memory. See [claude-plugin/README.md](claude-plugin/README.md) for details.
+
+### Manual Claude Code Configuration
 
 Add to `~/.claude.json` under `mcpServers` (global) or in your project settings:
 
@@ -242,6 +265,32 @@ Add to `~/.claude.json` under `mcpServers` (global) or in your project settings:
 | **`like_memory`** | Upvote a memory (increases relevance) |
 | **`dislike_memory`** | Downvote a memory (decreases relevance) |
 | **`list_memories`** | List all stored memories |
+
+### Importing Claude Code Session History
+
+Import your past Claude Code sessions as searchable memories:
+
+```bash
+python3 scripts/import_claude_history.py
+```
+
+This parses `~/.claude/history.jsonl`, groups prompts by session, and creates one memory per session. Filter what gets imported:
+
+```bash
+# Only sessions in a specific project
+python3 scripts/import_claude_history.py --project /path/to/project
+
+# Only sessions after a date
+python3 scripts/import_claude_history.py --after 2025-06-01
+
+# Only sessions mentioning a keyword
+python3 scripts/import_claude_history.py --keyword "DynamoDB"
+
+# Preview without importing
+python3 scripts/import_claude_history.py --dry-run
+```
+
+Note: Only user prompts are stored locally by Claude Code; assistant responses are not available. Despite this, user prompts provide good semantic search targets for recalling past work.
 
 ## Concepts
 

--- a/claude-plugin/README.md
+++ b/claude-plugin/README.md
@@ -1,0 +1,60 @@
+# voitta-rag Claude Code Plugin
+
+Connects [Claude Code](https://docs.anthropic.com/en/docs/claude-code) to your voitta-rag instance.
+
+## What it does
+
+1. **MCP Server** — Configures voitta-rag as an MCP server so Claude Code can search your indexed documents and memories.
+2. **Session Memory Hook** (optional) — Installs a `Stop` hook that prompts Claude to save a summary of each session as a voitta-rag memory before ending.
+
+## Setup
+
+```bash
+# Basic: MCP server only
+bash claude-plugin/setup.sh
+
+# With session memory hook
+bash claude-plugin/setup.sh --with-hook
+
+# Docker mode (port 58000)
+bash claude-plugin/setup.sh --docker
+
+# Custom URL
+bash claude-plugin/setup.sh --url http://my-server:8000
+
+# Combine options
+bash claude-plugin/setup.sh --docker --with-hook
+```
+
+Restart Claude Code after setup.
+
+## Uninstall
+
+```bash
+bash claude-plugin/setup.sh --uninstall
+```
+
+## How the session memory hook works
+
+When installed, the hook runs each time Claude finishes responding. On the **first stop** of a session, it asks Claude to save a brief summary of what was accomplished as a memory. Subsequent stops in the same session are unaffected.
+
+Memories are stored in your voitta-rag Anamnesis folder and become searchable via semantic search — useful for recalling past work ("what did I debug last week?").
+
+## Importing past session history
+
+To import your existing Claude Code session history as memories:
+
+```bash
+python3 scripts/import_claude_history.py
+
+# Filter by project
+python3 scripts/import_claude_history.py --project /path/to/project
+
+# Filter by date
+python3 scripts/import_claude_history.py --after 2025-01-01
+
+# Dry run first
+python3 scripts/import_claude_history.py --dry-run
+```
+
+See `python3 scripts/import_claude_history.py --help` for all options.

--- a/claude-plugin/README.md
+++ b/claude-plugin/README.md
@@ -4,8 +4,8 @@ Connects [Claude Code](https://docs.anthropic.com/en/docs/claude-code) to your v
 
 ## What it does
 
-1. **MCP Server** — Configures voitta-rag as an MCP server so Claude Code can search your indexed documents and memories.
-2. **Session Memory Hook** (optional) — Installs a `Stop` hook that prompts Claude to save a summary of each session as a voitta-rag memory before ending.
+1. **MCP Server** — Configures voitta-rag as an MCP server in `~/.claude.json`, including the `X-User-Name` header so memory tools (`create_memory`, etc.) can identify the user.
+2. **Session Memory Hook** (optional) — Installs a `SessionEnd` hook that reads the session transcript on exit and saves it as a voitta-rag memory via `create_memory`. One memory per session, created automatically when the session ends.
 
 ## Setup
 
@@ -13,17 +13,17 @@ Connects [Claude Code](https://docs.anthropic.com/en/docs/claude-code) to your v
 # Basic: MCP server only
 bash claude-plugin/setup.sh
 
-# With session memory hook
-bash claude-plugin/setup.sh --with-hook
-
 # Docker mode (port 58000)
 bash claude-plugin/setup.sh --docker
 
-# Custom URL
-bash claude-plugin/setup.sh --url http://my-server:8000
-
-# Combine options
+# With session memory hook
 bash claude-plugin/setup.sh --docker --with-hook
+
+# Custom user name (defaults to $USER)
+bash claude-plugin/setup.sh --docker --with-hook --user alice
+
+# Custom voitta-rag URL
+bash claude-plugin/setup.sh --url http://my-server:8000
 ```
 
 Restart Claude Code after setup.
@@ -36,25 +36,49 @@ bash claude-plugin/setup.sh --uninstall
 
 ## How the session memory hook works
 
-When installed, the hook runs each time Claude finishes responding. On the **first stop** of a session, it asks Claude to save a brief summary of what was accomplished as a memory. Subsequent stops in the same session are unaffected.
+The hook uses Claude Code's `SessionEnd` event, which fires once per session when the user ends it (`/exit`, terminal close, etc.). Unlike `Stop` (which fires after every assistant turn), `SessionEnd` is exactly once per session.
 
-Memories are stored in your voitta-rag Anamnesis folder and become searchable via semantic search — useful for recalling past work ("what did I debug last week?").
+When the hook runs:
+
+1. Claude Code passes the hook a JSON payload on stdin containing `session_id`, `transcript_path`, `cwd`, and `reason`.
+2. The hook reads the transcript JSONL file at `transcript_path`.
+3. It extracts all user prompts and assistant text responses (tool calls are skipped).
+4. It formats the conversation as markdown and POSTs it to voitta-rag's `create_memory` MCP tool.
+
+The memory is then searchable via semantic search — useful for recalling past work ("what did I debug last week?", "when did I set up the Grafana alerts?").
+
+## Configuration
+
+The hook is configured via environment variables baked into the `settings.json` entry by `setup.sh`:
+
+- `VOITTA_URL` — base URL of voitta-rag (e.g. `http://localhost:58000` for Docker)
+- `VOITTA_USER` — user name for the `X-User-Name` header
+
+Re-run `setup.sh --with-hook --user NAME` to change them.
+
+## Failure handling
+
+If the voitta-rag instance is down or the API call fails, the hook logs an error to stderr (visible in Claude Code's session-end output) but **never fails the session close**. We don't want a memory save error to block you from exiting.
 
 ## Importing past session history
 
-To import your existing Claude Code session history as memories:
+To backfill existing Claude Code session history as memories:
 
 ```bash
-python3 scripts/import_claude_history.py
+python3 scripts/import_claude_history.py --voitta-url http://localhost:58000
 
 # Filter by project
-python3 scripts/import_claude_history.py --project /path/to/project
+python3 scripts/import_claude_history.py --voitta-url http://localhost:58000 \
+    --project /path/to/project
 
 # Filter by date
-python3 scripts/import_claude_history.py --after 2025-01-01
+python3 scripts/import_claude_history.py --voitta-url http://localhost:58000 \
+    --after 2025-01-01
 
 # Dry run first
 python3 scripts/import_claude_history.py --dry-run
 ```
 
-See `python3 scripts/import_claude_history.py --help` for all options.
+The import script parses `~/.claude/history.jsonl` (which stores user prompts only) and groups them by session. See `python3 scripts/import_claude_history.py --help` for all options.
+
+Note: `history.jsonl` only has user prompts — not assistant responses. The `SessionEnd` hook, by contrast, reads the full transcript and captures both sides of the conversation.

--- a/claude-plugin/hooks/session-memory.py
+++ b/claude-plugin/hooks/session-memory.py
@@ -1,0 +1,222 @@
+#!/usr/bin/env python3
+"""SessionEnd hook that creates a voitta-rag memory from a Claude Code session.
+
+Reads hook input JSON from stdin, then reads the transcript JSONL file pointed
+to by transcript_path. Extracts user prompts and assistant text responses,
+formats them as markdown, and POSTs to voitta-rag's create_memory MCP tool.
+
+Configured via env vars (set by setup.sh):
+    VOITTA_URL   voitta-rag base URL (default: http://localhost:8000)
+    VOITTA_USER  X-User-Name header  (default: $USER)
+
+Failures are logged to stderr but do not fail the hook — we never want to
+break the user's session close on a memory save error.
+"""
+
+import json
+import os
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+
+import urllib.request
+import urllib.error
+
+
+def read_hook_input() -> dict:
+    """Read the JSON payload Claude Code sends on stdin."""
+    raw = sys.stdin.read()
+    if not raw:
+        return {}
+    return json.loads(raw)
+
+
+def extract_turns(transcript_path: Path) -> list[dict]:
+    """Extract user prompts and assistant text responses from a transcript.
+
+    Returns list of {role, text, timestamp} in chronological order.
+    Skips tool calls, tool results, and system messages.
+    """
+    turns = []
+    with open(transcript_path, "r", encoding="utf-8") as f:
+        for line in f:
+            line = line.strip()
+            if not line:
+                continue
+            try:
+                entry = json.loads(line)
+            except json.JSONDecodeError:
+                continue
+
+            etype = entry.get("type")
+            if etype not in ("user", "assistant"):
+                continue
+
+            msg = entry.get("message", {})
+            content = msg.get("content")
+            ts = entry.get("timestamp", "")
+
+            if etype == "user":
+                # User content may be a string or a list with text/image parts
+                text = _flatten_user_content(content)
+                if text:
+                    turns.append({"role": "user", "text": text, "timestamp": ts})
+            else:  # assistant
+                text = _flatten_assistant_content(content)
+                if text:
+                    turns.append({"role": "assistant", "text": text, "timestamp": ts})
+
+    return turns
+
+
+def _flatten_user_content(content) -> str:
+    """User messages: content is either a string or list of parts. Skip tool_result."""
+    if isinstance(content, str):
+        return content.strip()
+    if isinstance(content, list):
+        parts = []
+        for part in content:
+            if isinstance(part, dict) and part.get("type") == "text":
+                parts.append(part.get("text", ""))
+            elif isinstance(part, str):
+                parts.append(part)
+        return "\n".join(p for p in parts if p).strip()
+    return ""
+
+
+def _flatten_assistant_content(content) -> str:
+    """Assistant messages: extract text blocks, skip tool_use."""
+    if isinstance(content, str):
+        return content.strip()
+    if isinstance(content, list):
+        parts = []
+        for part in content:
+            if isinstance(part, dict) and part.get("type") == "text":
+                parts.append(part.get("text", ""))
+        return "\n".join(p for p in parts if p).strip()
+    return ""
+
+
+def format_memory(session_id: str, cwd: str, reason: str, turns: list[dict]) -> str:
+    """Format session turns as markdown for memory storage."""
+    if not turns:
+        return ""
+
+    first_ts = turns[0].get("timestamp", "")
+    last_ts = turns[-1].get("timestamp", "")
+    user_count = sum(1 for t in turns if t["role"] == "user")
+    asst_count = sum(1 for t in turns if t["role"] == "assistant")
+
+    lines = []
+    lines.append("# Claude Code Session")
+    lines.append("")
+    lines.append(f"**Session ID:** {session_id}")
+    lines.append(f"**Working directory:** {cwd}")
+    lines.append(f"**Ended:** {reason}")
+    lines.append(f"**Range:** {first_ts} - {last_ts}")
+    lines.append(f"**Turns:** {user_count} user, {asst_count} assistant")
+    lines.append("")
+    lines.append("## Conversation")
+    lines.append("")
+
+    for t in turns:
+        role = "User" if t["role"] == "user" else "Assistant"
+        lines.append(f"### {role}")
+        lines.append("")
+        lines.append(t["text"])
+        lines.append("")
+
+    return "\n".join(lines)
+
+
+def post_create_memory(voitta_url: str, user_name: str, content: str) -> None:
+    """POST create_memory to the voitta-rag MCP endpoint."""
+    url = f"{voitta_url}/mcp/mcp"
+    payload = {
+        "jsonrpc": "2.0",
+        "id": 1,
+        "method": "tools/call",
+        "params": {
+            "name": "create_memory",
+            "arguments": {"content": content},
+        },
+    }
+    data = json.dumps(payload).encode("utf-8")
+    req = urllib.request.Request(
+        url,
+        data=data,
+        headers={
+            "Content-Type": "application/json",
+            "Accept": "application/json, text/event-stream",
+            "X-User-Name": user_name,
+        },
+        method="POST",
+    )
+    with urllib.request.urlopen(req, timeout=30) as resp:
+        body = resp.read().decode("utf-8")
+        ctype = resp.headers.get("content-type", "")
+        if "text/event-stream" in ctype:
+            for line in body.splitlines():
+                if line.startswith("data: "):
+                    result = json.loads(line[6:])
+                    break
+            else:
+                raise RuntimeError("No data frame in SSE response")
+        else:
+            result = json.loads(body)
+
+        if "error" in result:
+            raise RuntimeError(f"MCP error: {result['error']}")
+
+
+def main() -> int:
+    try:
+        hook_input = read_hook_input()
+    except Exception as e:
+        print(f"voitta-rag session-memory: bad hook input: {e}", file=sys.stderr)
+        return 0
+
+    transcript_path_str = hook_input.get("transcript_path", "")
+    session_id = hook_input.get("session_id", "unknown")
+    cwd = hook_input.get("cwd", "")
+    reason = hook_input.get("reason", "unknown")
+
+    if not transcript_path_str:
+        print("voitta-rag session-memory: no transcript_path in hook input", file=sys.stderr)
+        return 0
+
+    transcript_path = Path(transcript_path_str)
+    if not transcript_path.exists():
+        print(f"voitta-rag session-memory: transcript not found: {transcript_path}", file=sys.stderr)
+        return 0
+
+    try:
+        turns = extract_turns(transcript_path)
+    except Exception as e:
+        print(f"voitta-rag session-memory: failed to read transcript: {e}", file=sys.stderr)
+        return 0
+
+    if not turns:
+        print("voitta-rag session-memory: no user/assistant turns — skipping", file=sys.stderr)
+        return 0
+
+    content = format_memory(session_id, cwd, reason, turns)
+
+    voitta_url = os.environ.get("VOITTA_URL", "http://localhost:8000")
+    voitta_user = os.environ.get("VOITTA_USER", os.environ.get("USER", "anonymous"))
+
+    try:
+        post_create_memory(voitta_url, voitta_user, content)
+        print(
+            f"voitta-rag session-memory: saved session {session_id[:8]} "
+            f"({len(turns)} turns) to {voitta_url}",
+            file=sys.stderr,
+        )
+    except Exception as e:
+        print(f"voitta-rag session-memory: failed to create memory: {e}", file=sys.stderr)
+
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/claude-plugin/hooks/session-memory.sh
+++ b/claude-plugin/hooks/session-memory.sh
@@ -1,0 +1,26 @@
+#!/usr/bin/env bash
+#
+# voitta-rag session memory hook (Stop event)
+#
+# On first invocation per Claude Code session, blocks the stop and asks
+# the assistant to save a session summary as a voitta-rag memory.
+# Subsequent invocations in the same session approve silently.
+#
+# Uses a marker file in /tmp keyed by parent PID (the Claude Code process).
+
+MARKER="/tmp/voitta-session-memory-$$-${PPID}"
+
+# Clean up stale markers older than 24 hours
+find /tmp -maxdepth 1 -name "voitta-session-memory-*" -mmin +1440 -delete 2>/dev/null || true
+
+if [[ -f "$MARKER" ]]; then
+    # Already prompted this session — allow stop
+    exit 0
+fi
+
+# First stop in this session — create marker and block
+touch "$MARKER"
+
+cat <<'EOF'
+{"decision": "block", "reason": "Before ending this session, please save a brief summary of what was accomplished as a voitta-rag memory using the create_memory tool. Include: what was worked on, key decisions made, and any unfinished items. Then you may stop."}
+EOF

--- a/claude-plugin/hooks/session-memory.sh
+++ b/claude-plugin/hooks/session-memory.sh
@@ -1,26 +1,15 @@
 #!/usr/bin/env bash
 #
-# voitta-rag session memory hook (Stop event)
+# voitta-rag SessionEnd hook
 #
-# On first invocation per Claude Code session, blocks the stop and asks
-# the assistant to save a session summary as a voitta-rag memory.
-# Subsequent invocations in the same session approve silently.
+# On Claude Code session end, reads the session transcript and creates a
+# voitta-rag memory summarising the user prompts from the session.
 #
-# Uses a marker file in /tmp keyed by parent PID (the Claude Code process).
+# Config via env vars (set by setup.sh):
+#   VOITTA_URL   voitta-rag base URL (default: http://localhost:8000)
+#   VOITTA_USER  X-User-Name header (default: $USER)
 
-MARKER="/tmp/voitta-session-memory-$$-${PPID}"
+set -euo pipefail
 
-# Clean up stale markers older than 24 hours
-find /tmp -maxdepth 1 -name "voitta-session-memory-*" -mmin +1440 -delete 2>/dev/null || true
-
-if [[ -f "$MARKER" ]]; then
-    # Already prompted this session — allow stop
-    exit 0
-fi
-
-# First stop in this session — create marker and block
-touch "$MARKER"
-
-cat <<'EOF'
-{"decision": "block", "reason": "Before ending this session, please save a brief summary of what was accomplished as a voitta-rag memory using the create_memory tool. Include: what was worked on, key decisions made, and any unfinished items. Then you may stop."}
-EOF
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+exec python3 "$SCRIPT_DIR/session-memory.py"

--- a/claude-plugin/setup.sh
+++ b/claude-plugin/setup.sh
@@ -1,0 +1,113 @@
+#!/usr/bin/env bash
+#
+# voitta-rag Claude Code plugin setup
+#
+# Configures:
+#   1. MCP server in ~/.claude.json
+#   2. (Optional) Stop hook that prompts session memory creation
+#
+# Usage:
+#   bash claude-plugin/setup.sh [--with-hook] [--url URL]
+#
+# Options:
+#   --with-hook   Install the Stop hook for session memory creation
+#   --url URL     voitta-rag base URL (default: http://localhost:8000)
+#   --docker      Use Docker URL (http://localhost:58000)
+#   --uninstall   Remove voitta-rag MCP server and hook
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+CLAUDE_JSON="$HOME/.claude.json"
+SETTINGS_JSON="$HOME/.claude/settings.json"
+HOOK_SCRIPT="$SCRIPT_DIR/hooks/session-memory.sh"
+
+VOITTA_URL="http://localhost:8000"
+INSTALL_HOOK=false
+UNINSTALL=false
+
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --with-hook) INSTALL_HOOK=true; shift ;;
+        --url) VOITTA_URL="$2"; shift 2 ;;
+        --docker) VOITTA_URL="http://localhost:58000"; shift ;;
+        --uninstall) UNINSTALL=true; shift ;;
+        *) echo "Unknown option: $1"; exit 1 ;;
+    esac
+done
+
+MCP_URL="${VOITTA_URL}/mcp/mcp"
+
+# Ensure jq is available
+if ! command -v jq &>/dev/null; then
+    echo "Error: jq is required. Install with: brew install jq (macOS) or apt install jq (Linux)"
+    exit 1
+fi
+
+# --- Uninstall ---
+if $UNINSTALL; then
+    echo "Removing voitta-rag from Claude Code configuration..."
+
+    if [[ -f "$CLAUDE_JSON" ]]; then
+        jq 'del(.mcpServers["voitta-rag"])' "$CLAUDE_JSON" > "${CLAUDE_JSON}.tmp" \
+            && mv "${CLAUDE_JSON}.tmp" "$CLAUDE_JSON"
+        echo "  Removed MCP server from $CLAUDE_JSON"
+    fi
+
+    if [[ -f "$SETTINGS_JSON" ]]; then
+        jq 'if .hooks.Stop then .hooks.Stop = [.hooks.Stop[] | select(.hooks[0].command != "'"$HOOK_SCRIPT"'")] | if .hooks.Stop == [] then del(.hooks.Stop) else . end else . end' \
+            "$SETTINGS_JSON" > "${SETTINGS_JSON}.tmp" \
+            && mv "${SETTINGS_JSON}.tmp" "$SETTINGS_JSON"
+        echo "  Removed Stop hook from $SETTINGS_JSON"
+    fi
+
+    echo "Done."
+    exit 0
+fi
+
+# --- Install MCP server ---
+echo "Configuring voitta-rag MCP server..."
+
+if [[ ! -f "$CLAUDE_JSON" ]]; then
+    echo '{}' > "$CLAUDE_JSON"
+fi
+
+jq --arg url "$MCP_URL" '.mcpServers["voitta-rag"] = {"type": "http", "url": $url}' \
+    "$CLAUDE_JSON" > "${CLAUDE_JSON}.tmp" \
+    && mv "${CLAUDE_JSON}.tmp" "$CLAUDE_JSON"
+
+echo "  MCP server configured at $MCP_URL"
+echo "  Config: $CLAUDE_JSON"
+
+# --- Install Stop hook ---
+if $INSTALL_HOOK; then
+    echo ""
+    echo "Installing session memory hook..."
+
+    chmod +x "$HOOK_SCRIPT"
+
+    if [[ ! -f "$SETTINGS_JSON" ]]; then
+        mkdir -p "$(dirname "$SETTINGS_JSON")"
+        echo '{}' > "$SETTINGS_JSON"
+    fi
+
+    # Check if hook already exists
+    HOOK_EXISTS=$(jq --arg cmd "$HOOK_SCRIPT" '
+        .hooks.Stop // [] | any(.hooks[]; .command == $cmd)
+    ' "$SETTINGS_JSON")
+
+    if [[ "$HOOK_EXISTS" == "true" ]]; then
+        echo "  Hook already installed"
+    else
+        jq --arg cmd "$HOOK_SCRIPT" '
+            .hooks.Stop = (.hooks.Stop // []) + [{"hooks": [{"type": "command", "command": $cmd}]}]
+        ' "$SETTINGS_JSON" > "${SETTINGS_JSON}.tmp" \
+            && mv "${SETTINGS_JSON}.tmp" "$SETTINGS_JSON"
+        echo "  Stop hook installed: $HOOK_SCRIPT"
+    fi
+
+    echo "  Config: $SETTINGS_JSON"
+fi
+
+echo ""
+echo "Setup complete. Restart Claude Code to apply changes."

--- a/claude-plugin/setup.sh
+++ b/claude-plugin/setup.sh
@@ -3,16 +3,17 @@
 # voitta-rag Claude Code plugin setup
 #
 # Configures:
-#   1. MCP server in ~/.claude.json
-#   2. (Optional) Stop hook that prompts session memory creation
+#   1. MCP server in ~/.claude.json with X-User-Name header
+#   2. (Optional) SessionEnd hook that saves a session transcript as a memory
 #
 # Usage:
-#   bash claude-plugin/setup.sh [--with-hook] [--url URL]
+#   bash claude-plugin/setup.sh [--with-hook] [--url URL] [--user NAME]
 #
 # Options:
-#   --with-hook   Install the Stop hook for session memory creation
+#   --with-hook   Install SessionEnd hook that saves session as a memory
 #   --url URL     voitta-rag base URL (default: http://localhost:8000)
 #   --docker      Use Docker URL (http://localhost:58000)
+#   --user NAME   User name for X-User-Name header (default: $USER)
 #   --uninstall   Remove voitta-rag MCP server and hook
 
 set -euo pipefail
@@ -23,6 +24,7 @@ SETTINGS_JSON="$HOME/.claude/settings.json"
 HOOK_SCRIPT="$SCRIPT_DIR/hooks/session-memory.sh"
 
 VOITTA_URL="http://localhost:8000"
+VOITTA_USER="${USER:-anonymous}"
 INSTALL_HOOK=false
 UNINSTALL=false
 
@@ -31,6 +33,7 @@ while [[ $# -gt 0 ]]; do
         --with-hook) INSTALL_HOOK=true; shift ;;
         --url) VOITTA_URL="$2"; shift 2 ;;
         --docker) VOITTA_URL="http://localhost:58000"; shift ;;
+        --user) VOITTA_USER="$2"; shift 2 ;;
         --uninstall) UNINSTALL=true; shift ;;
         *) echo "Unknown option: $1"; exit 1 ;;
     esac
@@ -55,10 +58,19 @@ if $UNINSTALL; then
     fi
 
     if [[ -f "$SETTINGS_JSON" ]]; then
-        jq 'if .hooks.Stop then .hooks.Stop = [.hooks.Stop[] | select(.hooks[0].command != "'"$HOOK_SCRIPT"'")] | if .hooks.Stop == [] then del(.hooks.Stop) else . end else . end' \
-            "$SETTINGS_JSON" > "${SETTINGS_JSON}.tmp" \
+        # Remove voitta-rag hook from both Stop (legacy) and SessionEnd
+        jq --arg cmd "$HOOK_SCRIPT" '
+            if .hooks.Stop then
+                .hooks.Stop = [.hooks.Stop[] | select((.hooks // [])[0].command != $cmd)]
+                | if .hooks.Stop == [] then del(.hooks.Stop) else . end
+            else . end
+            | if .hooks.SessionEnd then
+                .hooks.SessionEnd = [.hooks.SessionEnd[] | select((.hooks // [])[0].command != $cmd)]
+                | if .hooks.SessionEnd == [] then del(.hooks.SessionEnd) else . end
+            else . end
+        ' "$SETTINGS_JSON" > "${SETTINGS_JSON}.tmp" \
             && mv "${SETTINGS_JSON}.tmp" "$SETTINGS_JSON"
-        echo "  Removed Stop hook from $SETTINGS_JSON"
+        echo "  Removed hooks from $SETTINGS_JSON"
     fi
 
     echo "Done."
@@ -72,14 +84,20 @@ if [[ ! -f "$CLAUDE_JSON" ]]; then
     echo '{}' > "$CLAUDE_JSON"
 fi
 
-jq --arg url "$MCP_URL" '.mcpServers["voitta-rag"] = {"type": "http", "url": $url}' \
-    "$CLAUDE_JSON" > "${CLAUDE_JSON}.tmp" \
+jq --arg url "$MCP_URL" --arg user "$VOITTA_USER" '
+    .mcpServers["voitta-rag"] = {
+        "type": "http",
+        "url": $url,
+        "headers": {"X-User-Name": $user}
+    }
+' "$CLAUDE_JSON" > "${CLAUDE_JSON}.tmp" \
     && mv "${CLAUDE_JSON}.tmp" "$CLAUDE_JSON"
 
 echo "  MCP server configured at $MCP_URL"
+echo "  X-User-Name: $VOITTA_USER"
 echo "  Config: $CLAUDE_JSON"
 
-# --- Install Stop hook ---
+# --- Install SessionEnd hook ---
 if $INSTALL_HOOK; then
     echo ""
     echo "Installing session memory hook..."
@@ -91,21 +109,49 @@ if $INSTALL_HOOK; then
         echo '{}' > "$SETTINGS_JSON"
     fi
 
-    # Check if hook already exists
+    # Clean any legacy Stop hook pointing at the same script
+    jq --arg cmd "$HOOK_SCRIPT" '
+        if .hooks.Stop then
+            .hooks.Stop = [.hooks.Stop[] | select((.hooks // [])[0].command != $cmd)]
+            | if .hooks.Stop == [] then del(.hooks.Stop) else . end
+        else . end
+    ' "$SETTINGS_JSON" > "${SETTINGS_JSON}.tmp" \
+        && mv "${SETTINGS_JSON}.tmp" "$SETTINGS_JSON"
+
+    # Check if SessionEnd hook already exists for this script
     HOOK_EXISTS=$(jq --arg cmd "$HOOK_SCRIPT" '
-        .hooks.Stop // [] | any(.hooks[]; .command == $cmd)
+        [(.hooks.SessionEnd // [])[] | .hooks[]? | .command] | any(. == $cmd)
     ' "$SETTINGS_JSON")
 
+    HOOK_ENTRY=$(jq -n \
+        --arg cmd "$HOOK_SCRIPT" \
+        --arg url "$VOITTA_URL" \
+        --arg user "$VOITTA_USER" \
+        '{
+            "hooks": [{
+                "type": "command",
+                "command": "VOITTA_URL=\($url) VOITTA_USER=\($user) \($cmd)"
+            }]
+        }')
+
     if [[ "$HOOK_EXISTS" == "true" ]]; then
-        echo "  Hook already installed"
-    else
-        jq --arg cmd "$HOOK_SCRIPT" '
-            .hooks.Stop = (.hooks.Stop // []) + [{"hooks": [{"type": "command", "command": $cmd}]}]
+        # Replace existing entry to pick up latest URL/user
+        jq --arg cmd "$HOOK_SCRIPT" --argjson entry "$HOOK_ENTRY" '
+            .hooks.SessionEnd = [
+                (.hooks.SessionEnd[] | select((.hooks // [])[0].command | contains($cmd) | not))
+            ] + [$entry]
         ' "$SETTINGS_JSON" > "${SETTINGS_JSON}.tmp" \
             && mv "${SETTINGS_JSON}.tmp" "$SETTINGS_JSON"
-        echo "  Stop hook installed: $HOOK_SCRIPT"
+        echo "  SessionEnd hook updated"
+    else
+        jq --argjson entry "$HOOK_ENTRY" '
+            .hooks.SessionEnd = (.hooks.SessionEnd // []) + [$entry]
+        ' "$SETTINGS_JSON" > "${SETTINGS_JSON}.tmp" \
+            && mv "${SETTINGS_JSON}.tmp" "$SETTINGS_JSON"
+        echo "  SessionEnd hook installed"
     fi
 
+    echo "  VOITTA_URL=$VOITTA_URL VOITTA_USER=$VOITTA_USER"
     echo "  Config: $SETTINGS_JSON"
 fi
 

--- a/scripts/import_claude_history.py
+++ b/scripts/import_claude_history.py
@@ -146,12 +146,20 @@ def create_memory(voitta_url: str, user_name: str, content: str) -> dict:
     }
     headers = {
         "Content-Type": "application/json",
+        "Accept": "application/json, text/event-stream",
         "X-User-Name": user_name,
     }
     resp = requests.post(url, json=payload, headers=headers, timeout=30)
     resp.raise_for_status()
-    result = resp.json()
-    return result
+
+    # FastMCP streamable-http can return either JSON or SSE.
+    content_type = resp.headers.get("content-type", "")
+    if "text/event-stream" in content_type:
+        for line in resp.text.splitlines():
+            if line.startswith("data: "):
+                return json.loads(line[6:])
+        raise ValueError("No data frame in SSE response")
+    return resp.json()
 
 
 def main():

--- a/scripts/import_claude_history.py
+++ b/scripts/import_claude_history.py
@@ -1,0 +1,260 @@
+#!/usr/bin/env python3
+"""Import Claude Code session history as voitta-rag memories.
+
+Parses ~/.claude/history.jsonl, groups user prompts by sessionId,
+and creates one memory per session via the voitta-rag MCP HTTP API.
+
+Usage:
+    python3 scripts/import_claude_history.py [options]
+
+Options:
+    --voitta-url URL     Base URL of voitta-rag (default: http://localhost:8000)
+    --user NAME          User name for X-User-Name header (default: current OS user)
+    --history PATH       Path to history.jsonl (default: ~/.claude/history.jsonl)
+    --project FILTER     Only import sessions from this project/directory (substring match)
+    --after DATE         Only import sessions after this date (YYYY-MM-DD)
+    --before DATE        Only import sessions before this date (YYYY-MM-DD)
+    --keyword WORD       Only import sessions containing this keyword in prompts
+    --dry-run            Show what would be imported without creating memories
+"""
+
+import argparse
+import json
+import os
+import sys
+from collections import defaultdict
+from datetime import datetime, timezone
+from pathlib import Path
+
+import requests
+
+
+def parse_history(history_path: Path) -> list[dict]:
+    """Parse history.jsonl into a list of prompt records."""
+    entries = []
+    with open(history_path, "r", encoding="utf-8") as f:
+        for line_num, line in enumerate(f, 1):
+            line = line.strip()
+            if not line:
+                continue
+            try:
+                entry = json.loads(line)
+                entries.append(entry)
+            except json.JSONDecodeError:
+                print(f"  Warning: skipping malformed line {line_num}", file=sys.stderr)
+    return entries
+
+
+def group_by_session(entries: list[dict]) -> dict[str, list[dict]]:
+    """Group history entries by sessionId, sorted by timestamp within each session."""
+    sessions = defaultdict(list)
+    for entry in entries:
+        sid = entry.get("sessionId")
+        if not sid:
+            continue
+        sessions[sid].append(entry)
+    for sid in sessions:
+        sessions[sid].sort(key=lambda e: e.get("timestamp", 0))
+    return dict(sessions)
+
+
+def session_date_range(prompts: list[dict]) -> tuple[datetime, datetime]:
+    """Return (earliest, latest) datetime from a list of prompts."""
+    timestamps = [p["timestamp"] for p in prompts if "timestamp" in p]
+    earliest = datetime.fromtimestamp(min(timestamps) / 1000, tz=timezone.utc)
+    latest = datetime.fromtimestamp(max(timestamps) / 1000, tz=timezone.utc)
+    return earliest, latest
+
+
+def format_session_memory(session_id: str, prompts: list[dict]) -> str:
+    """Format a session's prompts into memory content."""
+    earliest, latest = session_date_range(prompts)
+    projects = set()
+    for p in prompts:
+        proj = p.get("project", "")
+        if proj:
+            projects.add(proj)
+
+    lines = []
+    lines.append(f"# Claude Code Session")
+    lines.append(f"")
+    lines.append(f"**Session ID:** {session_id}")
+    lines.append(f"**Date:** {earliest.strftime('%Y-%m-%d %H:%M')} - {latest.strftime('%Y-%m-%d %H:%M')} UTC")
+    if projects:
+        lines.append(f"**Project(s):** {', '.join(sorted(projects))}")
+    lines.append(f"**Prompts:** {len(prompts)}")
+    lines.append(f"")
+    lines.append(f"## User Prompts")
+    lines.append(f"")
+
+    for i, p in enumerate(prompts, 1):
+        ts = datetime.fromtimestamp(p["timestamp"] / 1000, tz=timezone.utc)
+        display = p.get("display", "")
+        lines.append(f"### Prompt {i} ({ts.strftime('%H:%M:%S')})")
+        lines.append(f"")
+        lines.append(display)
+        lines.append(f"")
+
+    result = "\n".join(lines)
+    return result
+
+
+def matches_filters(
+    prompts: list[dict],
+    project_filter: str | None,
+    after_date: datetime | None,
+    before_date: datetime | None,
+    keyword: str | None,
+) -> bool:
+    """Check whether a session matches all provided filters."""
+    if not prompts:
+        return False
+
+    earliest, latest = session_date_range(prompts)
+
+    if after_date and latest < after_date:
+        return False
+    if before_date and earliest > before_date:
+        return False
+
+    if project_filter:
+        session_projects = [p.get("project", "") for p in prompts]
+        found = any(project_filter in proj for proj in session_projects)
+        if not found:
+            return False
+
+    if keyword:
+        kw_lower = keyword.lower()
+        all_text = " ".join(p.get("display", "") for p in prompts).lower()
+        if kw_lower not in all_text:
+            return False
+
+    return True
+
+
+def create_memory(voitta_url: str, user_name: str, content: str) -> dict:
+    """Create a memory via the voitta-rag MCP endpoint."""
+    url = f"{voitta_url}/mcp/mcp"
+    payload = {
+        "jsonrpc": "2.0",
+        "id": 1,
+        "method": "tools/call",
+        "params": {
+            "name": "create_memory",
+            "arguments": {"content": content},
+        },
+    }
+    headers = {
+        "Content-Type": "application/json",
+        "X-User-Name": user_name,
+    }
+    resp = requests.post(url, json=payload, headers=headers, timeout=30)
+    resp.raise_for_status()
+    result = resp.json()
+    return result
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description="Import Claude Code session history as voitta-rag memories"
+    )
+    parser.add_argument(
+        "--voitta-url",
+        default=os.getenv("VOITTA_URL", "http://localhost:8000"),
+        help="Base URL of voitta-rag (default: http://localhost:8000)",
+    )
+    parser.add_argument(
+        "--user",
+        default=os.getenv("USER", "anonymous"),
+        help="User name for X-User-Name header",
+    )
+    parser.add_argument(
+        "--history",
+        default=str(Path.home() / ".claude" / "history.jsonl"),
+        help="Path to history.jsonl",
+    )
+    parser.add_argument(
+        "--project",
+        default=None,
+        help="Only import sessions from this project/directory (substring match)",
+    )
+    parser.add_argument(
+        "--after",
+        default=None,
+        help="Only import sessions after this date (YYYY-MM-DD)",
+    )
+    parser.add_argument(
+        "--before",
+        default=None,
+        help="Only import sessions before this date (YYYY-MM-DD)",
+    )
+    parser.add_argument(
+        "--keyword",
+        default=None,
+        help="Only import sessions containing this keyword in prompts",
+    )
+    parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="Show what would be imported without creating memories",
+    )
+
+    args = parser.parse_args()
+
+    history_path = Path(args.history)
+    if not history_path.exists():
+        print(f"Error: history file not found: {history_path}", file=sys.stderr)
+        sys.exit(1)
+
+    after_date = None
+    if args.after:
+        after_date = datetime.strptime(args.after, "%Y-%m-%d").replace(tzinfo=timezone.utc)
+
+    before_date = None
+    if args.before:
+        before_date = datetime.strptime(args.before, "%Y-%m-%d").replace(tzinfo=timezone.utc)
+
+    print(f"Reading {history_path}...")
+    entries = parse_history(history_path)
+    print(f"  Found {len(entries)} prompt entries")
+
+    sessions = group_by_session(entries)
+    print(f"  Found {len(sessions)} sessions")
+
+    matched = 0
+    imported = 0
+    for session_id, prompts in sorted(sessions.items(), key=lambda kv: min(p.get("timestamp", 0) for p in kv[1])):
+        if not matches_filters(prompts, args.project, after_date, before_date, args.keyword):
+            continue
+        matched += 1
+
+        earliest, latest = session_date_range(prompts)
+        projects = set(p.get("project", "") for p in prompts if p.get("project"))
+        proj_str = ", ".join(sorted(projects)) if projects else "(none)"
+
+        print(f"\n  Session {session_id[:8]}...")
+        print(f"    Date: {earliest.strftime('%Y-%m-%d %H:%M')} - {latest.strftime('%H:%M')} UTC")
+        print(f"    Project: {proj_str}")
+        print(f"    Prompts: {len(prompts)}")
+
+        if args.dry_run:
+            print(f"    [dry-run] Would create memory")
+            continue
+
+        content = format_session_memory(session_id, prompts)
+        try:
+            result = create_memory(args.voitta_url, args.user, content)
+            error = result.get("error")
+            if error:
+                print(f"    Error: {error}", file=sys.stderr)
+            else:
+                imported += 1
+                print(f"    Created memory")
+        except Exception as e:
+            print(f"    Error creating memory: {e}", file=sys.stderr)
+
+    print(f"\nDone. Matched: {matched}, Imported: {imported}")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary

- **Claude Code plugin** (#24) — `claude-plugin/setup.sh` automates MCP server config in `~/.claude.json`, with an optional `Stop` hook that prompts Claude to save a session summary as a memory before ending.
- **Session history import** (#25) — `scripts/import_claude_history.py` parses `~/.claude/history.jsonl`, groups user prompts by session, and creates one voitta-rag memory per session, with filters for project/date/keyword.
- **README clarifications** (#24) — Docker vs local install sections now explicitly call out what runs where and which ports are used.

## Key implementation notes

The `Stop` hook uses a `/tmp` marker keyed by `$PPID` (the Claude Code process). First stop in a session: block and ask for a memory. Subsequent stops in the same session: pass through. Avoids infinite loops and noise across turns. Stale markers are garbage-collected after 24h.

The history import script calls the MCP HTTP endpoint directly (`/mcp/mcp`) with `X-User-Name` for auth, matching how voitta-rag identifies users in dev mode.

Closes #24, closes #25

## Test plan

- [ ] Run `bash claude-plugin/setup.sh --docker` on a clean machine, verify `~/.claude.json` has the MCP server entry
- [ ] Run `bash claude-plugin/setup.sh --docker --with-hook`, verify hook appears in `~/.claude/settings.json`
- [ ] Run `bash claude-plugin/setup.sh --uninstall`, verify both are removed
- [ ] In a Claude Code session with the hook installed, confirm the first stop triggers a `create_memory` call and subsequent stops pass through silently
- [ ] Run `python3 scripts/import_claude_history.py --dry-run` and verify session count matches expectations
- [ ] Run `python3 scripts/import_claude_history.py --project somepath --dry-run` and verify filter works
- [ ] Run without `--dry-run` against a running voitta-rag instance, verify memories appear in Anamnesis folder