### PR TITLE
Add Claude Code plugin manifest

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -1,0 +1,14 @@
+{
+  "name": "voitta-rag",
+  "owner": {
+    "name": "Voitta"
+  },
+  "description": "RAG knowledge base with MCP integration for Claude Code.",
+  "plugins": [
+    {
+      "name": "voitta-rag",
+      "source": "./",
+      "description": "RAG knowledge base with MCP integration - indexes documents, code repos, and provides semantic search."
+    }
+  ]
+}

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,0 +1,11 @@
+{
+  "name": "voitta-rag",
+  "description": "RAG knowledge base with MCP integration for Claude Code - indexes documents, code repos, and provides semantic search.",
+  "version": "0.1.0",
+  "author": {
+    "name": "Voitta"
+  },
+  "homepage": "https://github.com/voitta-ai/voitta-rag",
+  "repository": "https://github.com/voitta-ai/voitta-rag",
+  "license": "AGPL-3.0"
+}

--- a/README.md
+++ b/README.md
@@ -225,7 +225,16 @@ The MCP server runs embedded in the main app (no separate process needed) and ex
 
 ### Claude Code Plugin (automated setup)
 
-The fastest way to connect Claude Code to voitta-rag:
+voitta-rag ships as a [Claude Code plugin](https://code.claude.com/docs/en/plugins).
+This repo is its own marketplace, so install with:
+
+```
+/plugin marketplace add voitta-ai/voitta-rag
+/plugin install voitta-rag@voitta-rag
+```
+
+The MCP server URL depends on your deployment (Docker vs local), so after
+installing the plugin run the setup script to configure it:
 
 ```bash
 # Docker mode (port 58000)
@@ -238,7 +247,7 @@ bash claude-plugin/setup.sh
 bash claude-plugin/setup.sh --docker --with-hook
 ```
 
-The plugin configures the MCP server in `~/.claude.json` and optionally installs a `Stop` hook that prompts Claude to save a session summary as a memory. See [claude-plugin/README.md](claude-plugin/README.md) for details.
+See [claude-plugin/README.md](claude-plugin/README.md) for details.
 
 ### Manual Claude Code Configuration
 


### PR DESCRIPTION
## Summary
- Add `.claude-plugin/plugin.json` and `.claude-plugin/marketplace.json` so voitta-rag can be installed as a Claude Code plugin via the marketplace system
- Update README to document the `/plugin marketplace add` + `/plugin install` method alongside the existing `setup.sh` approach

## Test plan
- [ ] Run `/plugin marketplace add voitta-ai/voitta-rag` and verify no schema error
- [ ] Run `/plugin install voitta-rag@voitta-rag` and verify plugin installs
- [ ] Verify `setup.sh` still works for MCP server configuration

🤖 Generated with [Claude Code](https://claude.com/claude-code)