### PR TITLE
Expose MCP server port via configurable host mapping

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -60,6 +60,7 @@ VOITTA_SEED_USERS=false
 VOITTA_USERS_FILE=users.txt
 
 # Docker-specific settings (only used by docker-compose.yml)
-DOCKER_PORT=58000  # Host port mapped to container's 8000
+DOCKER_PORT=58000  # Host port mapped to container's 8000 (REST API + UI)
+MCP_DOCKER_PORT=8001  # Host port mapped to container's 8001 (MCP server)
 MODEL_CACHE_DIR=~/.cache/huggingface  # Host path to HuggingFace model cache
 SSH_KEY_DIR=~/.ssh  # Host path to SSH keys (for git sync)

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -13,6 +13,7 @@ services:
     restart: unless-stopped
     ports:
       - "${DOCKER_PORT:-58000}:8000"
+      - "${MCP_DOCKER_PORT:-8001}:8001"
     env_file: .env
     environment:
       - QDRANT_HOST=qdrant


### PR DESCRIPTION
## Summary

- Adds the MCP server port to `docker-compose.yml` so it's actually published to the host (it was already running inside the container per the existing `MCP_PORT` env var, just not reachable from outside).
- Makes the host-side mapping configurable via a new `MCP_DOCKER_PORT` env var, defaulting to `8001` to match the internal default. Mirrors the existing `DOCKER_PORT` pattern used for the REST API.
- Documents the new env var in `.env.sample` alongside `DOCKER_PORT`.

## Motivation

MCP-aware clients like Claude Code expect to reach voitta-rag's MCP server directly. Without this change, anything outside the container has to go through the REST API at `:58000` (cookie-auth web flow), which adds friction. With this, you can register voitta-rag as an MCP server in Claude Code via `claude mcp add voitta-rag --url http://localhost:8001/mcp` (or whatever you remap it to locally) and search the corpus from any session.

## Test plan

- [x] `docker compose config` parses cleanly with the new mapping
- [ ] `docker compose up -d` exposes port 8001 (or the configured override) on localhost
- [ ] `curl http://localhost:8001/mcp` returns something other than connection-refused (smoke test for reachability; full MCP handshake is client-side)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
