### PR TITLE
Phase 1: llm-tldr companion indexing for Git repos (PoC)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -40,6 +40,8 @@ dependencies = [
     "google-auth>=2.23.0",
     # AWS
     "boto3>=1.28.0",
+    # Static analysis (optional companion indexing for Git sources, see issue #15)
+    "llm-tldr>=0.1.0",
 ]
 
 [project.optional-dependencies]

--- a/requirements.txt
+++ b/requirements.txt
@@ -30,3 +30,6 @@ boto3>=1.28.0
 
 # MCP server
 fastmcp>=0.4.0
+
+# Static analysis (optional companion indexing for Git sources, see issue #15)
+llm-tldr>=0.1.0

--- a/src/voitta/api/routes/sync.py
+++ b/src/voitta/api/routes/sync.py
@@ -50,6 +50,7 @@ class GitHubConfig(BaseModel):
     username: str = ""  # For token auth (e.g. GitHub username or x-access-token)
     token: str = ""  # Personal access token (PAT)
     all_branches: bool = False
+    llm_tldr: bool = False  # Run llm-tldr static analysis on synced repo
 
 
 class AzureDevOpsConfig(BaseModel):
@@ -187,6 +188,7 @@ def _to_response(source: FolderSyncSource) -> SyncSourceResponse:
             username=source.gh_username or "",
             token=source.gh_pat or "",
             all_branches=source.gh_all_branches or False,
+            llm_tldr=source.gh_llm_tldr or False,
         )
     elif source.source_type == "azure_devops":
         ado = AzureDevOpsConfig(
@@ -837,6 +839,7 @@ async def upsert_sync_source(
         "gd_service_account_json", "gd_folder_id", "gd_client_id", "gd_client_secret",
         "gh_token", "gh_repo", "gh_branch", "gh_path",
         "gh_auth_method", "gh_username", "gh_pat", "gh_all_branches",
+        "gh_llm_tldr",
         "ado_tenant_id", "ado_client_id", "ado_client_secret",
         "ado_organization", "ado_project", "ado_url",
         "jira_url", "jira_project", "jira_token", "jira_auth_method", "jira_email",
@@ -876,6 +879,7 @@ async def upsert_sync_source(
         source.gh_username = request.github.username
         source.gh_pat = request.github.token
         source.gh_all_branches = request.github.all_branches
+        source.gh_llm_tldr = request.github.llm_tldr
     elif request.source_type == "azure_devops" and request.azure_devops:
         from ...services.sync.azure_devops import _parse_ado_url
         source.ado_tenant_id = request.azure_devops.tenant_id

--- a/src/voitta/db/models.py
+++ b/src/voitta/db/models.py
@@ -168,6 +168,7 @@ class FolderSyncSource(Base):
     gh_username: Mapped[str | None] = mapped_column(String(255), nullable=True)
     gh_pat: Mapped[str | None] = mapped_column(String(500), nullable=True)
     gh_all_branches: Mapped[bool | None] = mapped_column(Boolean, nullable=True, default=False)
+    gh_llm_tldr: Mapped[bool | None] = mapped_column(Boolean, nullable=True, default=False)
 
     # Azure DevOps credentials
     ado_tenant_id: Mapped[str | None] = mapped_column(String(255), nullable=True)
@@ -238,6 +239,22 @@ class IndexedFile(Base):
     chunk_count: Mapped[int] = mapped_column(Integer, default=0)
     source_created_at: Mapped[int | None] = mapped_column(Integer, nullable=True)
     source_modified_at: Mapped[int | None] = mapped_column(Integer, nullable=True)
+    indexed_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), default=utc_now)
+    updated_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), default=utc_now, onupdate=utc_now
+    )
+
+
+class LlmTldrIndexedFile(Base):
+    """Track llm-tldr companion analysis chunks per source file."""
+
+    __tablename__ = "llm_tldr_indexed_files"
+
+    id: Mapped[int] = mapped_column(Integer, primary_key=True)
+    folder_path: Mapped[str] = mapped_column(String(1000), nullable=False, index=True)
+    related_file: Mapped[str] = mapped_column(String(1000), nullable=False, index=True)
+    content_hash: Mapped[str] = mapped_column(String(64), nullable=False)
+    chunk_count: Mapped[int] = mapped_column(Integer, default=0)
     indexed_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), default=utc_now)
     updated_at: Mapped[datetime] = mapped_column(
         DateTime(timezone=True), default=utc_now, onupdate=utc_now

--- a/src/voitta/services/llm_tldr_indexer.py
+++ b/src/voitta/services/llm_tldr_indexer.py
@@ -1,0 +1,314 @@
+"""llm-tldr companion indexing.
+
+Runs `llm-tldr` static analysis over a synced Git repo and stores the
+structural summaries as companion chunks in Qdrant alongside the raw code
+chunks. Each chunk is tagged with ``source_type="llm-tldr-analysis"`` and
+``related_file`` pointing back to the originating source file.
+
+Phase 1 (PoC): delete-and-replace per sync. Incremental reindexing arrives
+in phase 2 of issue #15.
+"""
+
+import json
+import logging
+from datetime import datetime, timezone
+from pathlib import Path
+
+from sqlalchemy import delete
+from sqlalchemy.orm import Session
+
+from ..db.models import LlmTldrIndexedFile
+from .chunking import ChunkingService, get_chunking_service
+from .embedding import EmbeddingService, get_embedding_service
+from .sparse_embedding import SparseEmbeddingService, get_sparse_embedding_service
+from .vector_store import ChunkMetadata, VectorStoreService, get_vector_store
+
+logger = logging.getLogger(__name__)
+
+SOURCE_TYPE = "llm-tldr-analysis"
+
+# Subset of llm-tldr's supported extensions. Keep small for PoC; expand later.
+SUPPORTED_EXTENSIONS = {
+    ".py", ".ts", ".tsx", ".js", ".jsx", ".go", ".rs", ".java",
+    ".rb", ".php", ".swift", ".cs", ".kt", ".kts", ".scala", ".sc",
+    ".lua", ".luau", ".ex", ".exs", ".c", ".h", ".cpp", ".hpp",
+    ".cc", ".cxx", ".hh",
+}
+
+# Skip pathologically large source files — tree-sitter parsing cost grows
+# super-linearly and a single 10MB generated file would block sync.
+MAX_FILE_BYTES = 1_000_000
+
+
+class LlmTldrIndexer:
+    """Indexes llm-tldr structural analysis as companion chunks."""
+
+    def __init__(
+        self,
+        chunker: ChunkingService | None = None,
+        embedder: EmbeddingService | None = None,
+        sparse_embedder: SparseEmbeddingService | None = None,
+        vector_store: VectorStoreService | None = None,
+    ):
+        self.chunker = chunker or get_chunking_service()
+        self.embedder = embedder or get_embedding_service()
+        self.sparse_embedder = sparse_embedder or get_sparse_embedding_service()
+        self.vector_store = vector_store or get_vector_store()
+
+    def index_repo(
+        self,
+        repo_dir: Path,
+        folder_path: str,
+        index_folder: str,
+        db: Session,
+    ) -> dict:
+        """Run llm-tldr analysis over ``repo_dir`` and index companion chunks.
+
+        Args:
+            repo_dir: Local directory containing the cloned source files.
+            folder_path: Voitta-RAG folder_path the chunks belong to (e.g.
+                "myrepo/branches/main"). All companion chunks for this folder
+                are wiped and replaced.
+            index_folder: Folder at which indexing was triggered (the
+                top-level Git source folder, used for filtered searches).
+            db: Active SQLAlchemy session.
+
+        Returns:
+            Stats dict with files_analyzed, files_skipped, chunks_stored,
+            errors counts.
+        """
+        try:
+            from tldr.api import extract_file  # type: ignore
+        except ImportError as e:
+            logger.error(
+                "llm-tldr is not installed; skipping companion indexing: %s", e,
+            )
+            return {
+                "files_analyzed": 0, "files_skipped": 0,
+                "chunks_stored": 0, "errors": 1,
+            }
+
+        stats = {
+            "files_analyzed": 0, "files_skipped": 0,
+            "chunks_stored": 0, "errors": 0,
+        }
+
+        deleted = self.vector_store.delete_by_folder_and_source_type(
+            folder_path, SOURCE_TYPE,
+        )
+        logger.info(
+            "llm-tldr: wiped %d stale companion chunks for %s",
+            deleted, folder_path,
+        )
+        db.execute(
+            delete(LlmTldrIndexedFile).where(
+                LlmTldrIndexedFile.folder_path == folder_path
+            )
+        )
+        db.flush()
+
+        files = _collect_source_files(repo_dir)
+        logger.info(
+            "llm-tldr: analyzing %d source files under %s",
+            len(files), repo_dir,
+        )
+
+        for src in files:
+            rel = str(src.relative_to(repo_dir))
+            try:
+                info = extract_file(str(src), base_path=str(repo_dir))
+            except Exception as e:
+                logger.debug("llm-tldr extract failed for %s: %s", rel, e)
+                stats["files_skipped"] += 1
+                continue
+
+            text = _render_extract(rel, info)
+            if not text.strip():
+                stats["files_skipped"] += 1
+                continue
+
+            try:
+                chunks_stored = self._store_chunks(
+                    text=text,
+                    related_file=rel,
+                    folder_path=folder_path,
+                    index_folder=index_folder,
+                )
+            except Exception as e:
+                logger.exception(
+                    "llm-tldr: failed to store chunks for %s: %s", rel, e,
+                )
+                stats["errors"] += 1
+                continue
+
+            content_hash = _hash_text(text)
+            db.add(
+                LlmTldrIndexedFile(
+                    folder_path=folder_path,
+                    related_file=rel,
+                    content_hash=content_hash,
+                    chunk_count=chunks_stored,
+                )
+            )
+            stats["files_analyzed"] += 1
+            stats["chunks_stored"] += chunks_stored
+
+        db.commit()
+        logger.info("llm-tldr: indexing complete for %s: %s", folder_path, stats)
+        return stats
+
+    def _store_chunks(
+        self,
+        text: str,
+        related_file: str,
+        folder_path: str,
+        index_folder: str,
+    ) -> int:
+        chunks = self.chunker.chunk_text(text)
+        if not chunks:
+            return 0
+
+        texts = [c.text for c in chunks]
+        embeddings = self.embedder.embed_texts(texts)
+        sparse_vectors = self.sparse_embedder.embed_texts(texts)
+
+        indexed_at = datetime.now(timezone.utc).isoformat()
+        synthetic_path = f"llm-tldr://{folder_path}/{related_file}"
+        chunk_data = []
+        for chunk, embedding in zip(chunks, embeddings):
+            metadata = ChunkMetadata(
+                file_path=synthetic_path,
+                folder_path=folder_path,
+                index_folder=index_folder,
+                file_name=Path(related_file).name + ".tldr.md",
+                chunk_index=chunk.index,
+                total_chunks=len(chunks),
+                start_char=chunk.start_char,
+                end_char=chunk.end_char,
+                indexed_at=indexed_at,
+                source_type=SOURCE_TYPE,
+                related_file=related_file,
+            )
+            chunk_data.append((chunk.text, embedding, metadata))
+
+        self.vector_store.store_chunks(chunk_data, sparse_vectors=sparse_vectors)
+        return len(chunks)
+
+
+def _collect_source_files(repo_dir: Path) -> list[Path]:
+    files: list[Path] = []
+    for entry in repo_dir.rglob("*"):
+        if not entry.is_file():
+            continue
+        if any(part.startswith(".") for part in entry.relative_to(repo_dir).parts):
+            continue
+        if entry.suffix.lower() not in SUPPORTED_EXTENSIONS:
+            continue
+        try:
+            if entry.stat().st_size > MAX_FILE_BYTES:
+                continue
+        except OSError:
+            continue
+        files.append(entry)
+    return files
+
+
+def _render_extract(rel_path: str, info: dict) -> str:
+    """Render an llm-tldr extract_file dict as markdown text for chunking."""
+    lines: list[str] = []
+    lines.append(f"# llm-tldr analysis: {rel_path}")
+    lang = info.get("language") or "unknown"
+    lines.append(f"Language: {lang}")
+    docstring = info.get("docstring")
+    if docstring:
+        lines.append("")
+        lines.append("## Module docstring")
+        lines.append(docstring.strip())
+
+    imports = info.get("imports") or []
+    if imports:
+        lines.append("")
+        lines.append("## Imports")
+        for imp in imports:
+            lines.append(f"- {_render_import(imp)}")
+
+    functions = info.get("functions") or []
+    if functions:
+        lines.append("")
+        lines.append("## Functions")
+        for fn in functions:
+            lines.append(_render_function(fn))
+
+    classes = info.get("classes") or []
+    if classes:
+        lines.append("")
+        lines.append("## Classes")
+        for cls in classes:
+            lines.append(_render_class(cls))
+
+    call_graph = info.get("call_graph") or {}
+    if call_graph:
+        lines.append("")
+        lines.append("## Call graph")
+        lines.append("```json")
+        lines.append(json.dumps(call_graph, indent=2, default=str))
+        lines.append("```")
+
+    return "\n".join(lines)
+
+
+def _render_import(imp) -> str:
+    if isinstance(imp, dict):
+        module = imp.get("module") or imp.get("name") or ""
+        names = imp.get("names") or []
+        if names:
+            return f"{module} ({', '.join(map(str, names))})"
+        return str(module)
+    return str(imp)
+
+
+def _render_function(fn) -> str:
+    if not isinstance(fn, dict):
+        return f"- {fn}"
+    parts: list[str] = []
+    sig = fn.get("signature") or fn.get("name") or ""
+    parts.append(f"### {sig}")
+    if fn.get("docstring"):
+        parts.append(fn["docstring"].strip())
+    calls = fn.get("calls") or []
+    if calls:
+        parts.append(f"Calls: {', '.join(map(str, calls))}")
+    called_by = fn.get("called_by") or []
+    if called_by:
+        parts.append(f"Called by: {', '.join(map(str, called_by))}")
+    complexity = fn.get("complexity")
+    if complexity is not None:
+        parts.append(f"Cyclomatic complexity: {complexity}")
+    return "\n".join(parts)
+
+
+def _render_class(cls) -> str:
+    if not isinstance(cls, dict):
+        return f"- {cls}"
+    parts: list[str] = []
+    name = cls.get("name") or "(anonymous)"
+    bases = cls.get("bases") or cls.get("base_classes") or []
+    header = f"### class {name}"
+    if bases:
+        header += f"({', '.join(map(str, bases))})"
+    parts.append(header)
+    if cls.get("docstring"):
+        parts.append(cls["docstring"].strip())
+    methods = cls.get("methods") or []
+    for m in methods:
+        parts.append(_render_function(m))
+    return "\n".join(parts)
+
+
+def _hash_text(text: str) -> str:
+    import hashlib
+    return hashlib.sha256(text.encode("utf-8")).hexdigest()
+
+
+def get_llm_tldr_indexer() -> LlmTldrIndexer:
+    return LlmTldrIndexer()

--- a/src/voitta/services/sync/github.py
+++ b/src/voitta/services/sync/github.py
@@ -345,6 +345,28 @@ def _render_gh_run_md(run: dict, jobs: list[dict]) -> str:
     return "\n".join(lines)
 
 
+def _run_llm_tldr_indexing(local_root: Path, folder_path: str) -> dict:
+    """Run llm-tldr companion indexing in a worker thread.
+
+    Spawned via asyncio.to_thread so it can use a sync DB Session and the
+    sync embedding/vector-store services without blocking the event loop.
+    """
+    from sqlalchemy.orm import Session
+
+    from ...db.database import get_sync_engine
+    from ..llm_tldr_indexer import get_llm_tldr_indexer
+
+    indexer = get_llm_tldr_indexer()
+    engine = get_sync_engine()
+    with Session(engine) as db:
+        return indexer.index_repo(
+            repo_dir=local_root,
+            folder_path=folder_path,
+            index_folder=folder_path,
+            db=db,
+        )
+
+
 class GitHubConnector(BaseSyncConnector):
     """Sync connector that uses git clone/pull for public, SSH, and token repos."""
 
@@ -517,6 +539,9 @@ class GitHubConnector(BaseSyncConnector):
           mirrored into the local folder.
         - If gh_all_branches is set, all remote branches are synced into
           branches/<branch_name>/ subfolders.
+        - If gh_llm_tldr is set, after the mirror finishes, runs llm-tldr
+          static analysis over the synced files and stores the structural
+          summaries as companion chunks in Qdrant.
         """
         folder_path = source.folder_path
         local_root = fs._resolve_path(folder_path)
@@ -529,21 +554,28 @@ class GitHubConnector(BaseSyncConnector):
             raise ValueError("Git repository URL is required")
 
         if getattr(source, "gh_all_branches", False):
-            return await self._sync_all_branches(
+            stats = await self._sync_all_branches(
                 source, repo_url, local_root, subfolder, folder_path,
                 keep_extensions,
             )
+        else:
+            branch = source.gh_branch or "main"
+            safe_name = branch.replace("/", "--")
+            branches_dir = local_root / "branches"
+            branches_dir.mkdir(parents=True, exist_ok=True)
+            branch_root = branches_dir / safe_name
+            branch_root.mkdir(parents=True, exist_ok=True)
+            stats = await self._sync_single_branch(
+                source, repo_url, branch, branch_root, subfolder, keep_extensions,
+            )
+            logger.info("Git sync complete for %s: %s", folder_path, stats)
 
-        branch = source.gh_branch or "main"
-        safe_name = branch.replace("/", "--")
-        branches_dir = local_root / "branches"
-        branches_dir.mkdir(parents=True, exist_ok=True)
-        branch_root = branches_dir / safe_name
-        branch_root.mkdir(parents=True, exist_ok=True)
-        stats = await self._sync_single_branch(
-            source, repo_url, branch, branch_root, subfolder, keep_extensions,
-        )
-        logger.info("Git sync complete for %s: %s", folder_path, stats)
+        if getattr(source, "gh_llm_tldr", False):
+            tldr_stats = await asyncio.to_thread(
+                _run_llm_tldr_indexing, local_root, folder_path,
+            )
+            stats["llm_tldr"] = tldr_stats
+
         return stats
 
     async def _sync_all_branches(

--- a/src/voitta/services/vector_store.py
+++ b/src/voitta/services/vector_store.py
@@ -39,6 +39,12 @@ class ChunkMetadata:
     allowed_users: list[str] | None = None
     # Source URL: original external URL (e.g. Google Docs link) for this document
     source_url: str | None = None
+    # Companion-chunk fields. When source_type is set, this chunk did not come
+    # from a literal file but from auxiliary analysis (e.g. llm-tldr static
+    # analysis). related_file points back to the original source file the
+    # analysis was derived from.
+    source_type: str | None = None
+    related_file: str | None = None
 
 
 @dataclass
@@ -84,6 +90,7 @@ class VectorStoreService:
             self._ensure_timestamp_indexes()
             self._ensure_acl_index()
             self._ensure_source_url_index()
+            self._ensure_companion_chunk_indexes()
         except (UnexpectedResponse, Exception):
             logger.info(f"Creating collection '{self.collection_name}'")
             self._client.create_collection(
@@ -99,7 +106,7 @@ class VectorStoreService:
                 },
             )
             # Create payload indexes for efficient filtering
-            for field in ("file_path", "folder_path", "index_folder", "allowed_users", "source_url"):
+            for field in ("file_path", "folder_path", "index_folder", "allowed_users", "source_url", "source_type", "related_file"):
                 self._client.create_payload_index(
                     collection_name=self.collection_name,
                     field_name=field,
@@ -159,6 +166,53 @@ class VectorStoreService:
                 logger.info(f"Created index for 'source_url' on '{self.collection_name}'")
         except Exception as e:
             logger.warning(f"Failed to ensure source_url index: {e}")
+
+    def _ensure_companion_chunk_indexes(self) -> None:
+        """Create KEYWORD payload indexes for source_type and related_file if missing."""
+        try:
+            info = self._client.get_collection(self.collection_name)
+            existing = set(info.payload_schema.keys()) if info.payload_schema else set()
+            for field in ("source_type", "related_file"):
+                if field not in existing:
+                    self._client.create_payload_index(
+                        collection_name=self.collection_name,
+                        field_name=field,
+                        field_schema=qmodels.PayloadSchemaType.KEYWORD,
+                    )
+                    logger.info(f"Created index for '{field}' on '{self.collection_name}'")
+        except Exception as e:
+            logger.warning(f"Failed to ensure companion-chunk indexes: {e}")
+
+    def delete_by_folder_and_source_type(self, folder_path: str, source_type: str) -> int:
+        """Delete all chunks for a folder with a specific source_type.
+
+        Used to wipe llm-tldr companion chunks before re-indexing.
+        """
+        flt = qmodels.Filter(
+            must=[
+                qmodels.FieldCondition(
+                    key="folder_path",
+                    match=qmodels.MatchValue(value=folder_path),
+                ),
+                qmodels.FieldCondition(
+                    key="source_type",
+                    match=qmodels.MatchValue(value=source_type),
+                ),
+            ]
+        )
+        count_result = self.client.count(
+            collection_name=self.collection_name, count_filter=flt,
+        )
+        count = count_result.count
+        if count > 0:
+            self.client.delete(
+                collection_name=self.collection_name,
+                points_selector=qmodels.FilterSelector(filter=flt),
+            )
+            logger.info(
+                f"Deleted {count} '{source_type}' chunks for folder: {folder_path}"
+            )
+        return count
 
     def find_by_source_url(self, source_url: str) -> list[StoredChunk]:
         """Find all chunks matching a given source_url.
@@ -286,6 +340,11 @@ class VectorStoreService:
             # Add source URL if present
             if metadata.source_url is not None:
                 payload["source_url"] = metadata.source_url
+            # Add companion-chunk fields if present
+            if metadata.source_type is not None:
+                payload["source_type"] = metadata.source_type
+            if metadata.related_file is not None:
+                payload["related_file"] = metadata.related_file
 
             # Build vector: unnamed dense + optional sparse
             if sparse_vectors and idx < len(sparse_vectors):
@@ -553,6 +612,8 @@ class VectorStoreService:
                 source_modified_at=payload.get("source_modified_at"),
                 allowed_users=payload.get("allowed_users"),
                 source_url=payload.get("source_url"),
+                source_type=payload.get("source_type"),
+                related_file=payload.get("related_file"),
             ),
             score=result.score,
         )

--- a/src/voitta/web/templates/browser.html
+++ b/src/voitta/web/templates/browser.html
@@ -318,6 +318,12 @@
                             <input type="password" id="gh-pat" class="sync-input" placeholder="ghp_... or github_pat_..." onblur="fetchGitBranches()">
                         </div>
                     </div>
+                    <div class="form-group-compact">
+                        <label style="display:flex; align-items:center; gap:6px; font-size:12px; cursor:pointer;">
+                            <input type="checkbox" id="gh-llm-tldr">
+                            Run llm-tldr static analysis (indexes structural summaries alongside code)
+                        </label>
+                    </div>
                 </div>
 
                 <!-- Azure DevOps Fields -->

--- a/static/js/app.js
+++ b/static/js/app.js
@@ -1067,6 +1067,7 @@ function populateSyncFields(data) {
         document.getElementById('gh-username').value = data.github.username || '';
         document.getElementById('gh-pat').value = data.github.token || '';
         document.getElementById('gh-all-branches').checked = !!data.github.all_branches;
+        document.getElementById('gh-llm-tldr').checked = !!data.github.llm_tldr;
         toggleGhAuth();
         toggleAllBranches();
         // Fetch branches and pre-select the saved one
@@ -1309,6 +1310,7 @@ function gatherSyncConfig() {
             username: document.getElementById('gh-username').value.trim(),
             token: document.getElementById('gh-pat').value.trim(),
             all_branches: document.getElementById('gh-all-branches').checked,
+            llm_tldr: document.getElementById('gh-llm-tldr').checked,
         };
     } else if (sourceType === 'azure_devops') {
         config.azure_devops = {


### PR DESCRIPTION
## Summary

Phase 1 of #15. When a Git source enables `gh_llm_tldr`, the sync runs `llm-tldr` static analysis (`tldr.api.extract_file`) over every supported source file and stores the structural summaries as companion chunks in Qdrant alongside the raw code chunks.

- Each companion chunk carries `source_type="llm-tldr-analysis"` and `related_file=<repo-relative source path>`.
- Standard voitta chunking + dense + sparse embeddings reused.
- Delete-and-replace on every sync (incremental reindex is phase 2).
- Optional dependency `llm-tldr` added to `requirements.txt` + `pyproject.toml`.

### Changes

- New flag `gh_llm_tldr` on `FolderSyncSource`.
- New table `llm_tldr_indexed_files` to track per-file analysis hashes for phase 2.
- `ChunkMetadata.source_type` + `related_file` fields, with KEYWORD payload indexes for Qdrant filtering.
- New service `LlmTldrIndexer` (`services/llm_tldr_indexer.py`).
- `GitHubConnector.sync()` invokes the indexer in a worker thread after mirroring finishes.
- API `GitHubConfig.llm_tldr` field + UI checkbox under the Git source form.

### Out of scope (later phases)

- Incremental per-file analysis on change (phase 2).
- Rich call-graph payload fields for filtered searches (phase 3).
- Post-commit hook (phase 4).
- Blog post (phase 5).

## Test plan

- [ ] Bring up dev stack with the branch checked out and `pip install -r requirements.txt`.
- [ ] In the UI, edit a Git source, tick "Run llm-tldr static analysis", save, sync.
- [ ] Confirm `last_synced_at` updates and stats include `"llm_tldr": {...}` in logs.
- [ ] Search in the UI / via MCP — results should mix raw code chunks and analysis chunks (different `source_type`), with the analysis chunks naming the related file.
- [ ] Re-sync — confirm prior `llm-tldr-analysis` chunks for the folder are wiped before being re-inserted.

Refs: #15