### PR TITLE
Phase 2.5: DB init fixes (WAL pragma + docker-managed gate)

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,8 @@ Useful for teams and individuals who want to:
   - [Customizing](#customizing)
   - [Exporting from a running instance](#exporting-from-a-running-instance)
   - [Round-trip between machines](#round-trip-between-machines)
+- [Advanced](#advanced)
+  - [SQLite journal mode on Docker bind-mounts](#sqlite-journal-mode-on-docker-bind-mounts)
 
 ## Features
 
@@ -435,4 +437,68 @@ python3 scripts/import_repos.py /tmp/repos.json
 ```
 
 If the target uses token auth, edit `/tmp/repos.json` on machine B to fill in `username` and `token` under each `hosts` entry before running the import. For SSH auth, make sure the target machine's SSH key is present on `~/.ssh` (mounted into the container) and authorized on GitHub.
+
+## Advanced
+
+### SQLite journal mode on Docker bind-mounts
+
+> **For operators only.** Skip this unless you hit the symptom below.
+
+voitta-rag stores its operational metadata in a SQLite database
+(`voitta.db`). By default SQLite picks rollback journaling (mode
+`delete`), which is the safe choice when the file lives on a Docker
+bind-mount from a macOS or Windows host. The application does **not**
+force a journal mode — it leaves whatever the file header specifies.
+
+**Symptom:** under sustained use on a bind-mounted setup (Docker
+Desktop, Rancher Desktop, OrbStack on macOS or Windows), some HTTP
+endpoints intermittently fail with:
+
+```
+sqlalchemy.exc.OperationalError: (sqlite3.OperationalError) disk I/O error
+```
+
+while `sqlite3 voitta.db "PRAGMA integrity_check;"` returns `ok` and
+the host can read the same query without issue. Restarting the
+container temporarily fixes it, then it comes back.
+
+**Root cause:** the database is using SQLite's WAL (write-ahead log)
+journal mode. WAL relies on a `-shm` shared-memory page that does not
+cross the host/VM file-sharing boundary cleanly. Stale `-shm`
+mappings — left over from a previous container session, laptop sleep,
+or a host-side process that touched the file — surface as EIO on the
+next query.
+
+**Fix:** force the database to use rollback journaling (mode `delete`)
+once. The setting is persisted in the SQLite file header and survives
+container restarts.
+
+```bash
+# 1. Stop the voitta-rag container so nothing has the DB open.
+docker compose stop voitta-rag
+
+# 2. Truncate any pending WAL and switch journal_mode on the file.
+sqlite3 $VOITTA_ROOT_PATH/voitta.db "PRAGMA wal_checkpoint(TRUNCATE);"
+sqlite3 $VOITTA_ROOT_PATH/voitta.db "PRAGMA journal_mode = DELETE;"
+
+# 3. Confirm the change stuck.
+sqlite3 $VOITTA_ROOT_PATH/voitta.db "PRAGMA journal_mode;"   # prints: delete
+
+# 4. Bring the container back up.
+docker compose start voitta-rag
+```
+
+**Trade-off:** rollback journaling serializes writes against reads, so
+on a single-writer / many-reader workload like voitta-rag the cost is
+modest. If your workload is write-heavy enough that you actually need
+WAL throughput and you are not on a bind-mount (e.g. you've moved the
+DB into a Docker named volume), you can force WAL the same way:
+
+```bash
+sqlite3 voitta.db "PRAGMA journal_mode = WAL;"
+```
+
+See also the [SQLite docs on journal mode](https://www.sqlite.org/pragma.html#pragma_journal_mode)
+and [WAL mode caveats on networked filesystems](https://www.sqlite.org/wal.html#sometimes_queries_return_sqlite_busy_in_wal_mode).
+
 

--- a/src/voitta/db/database.py
+++ b/src/voitta/db/database.py
@@ -18,9 +18,18 @@ from .models import Base, FolderSyncSource, Project, User
 
 
 def _set_sqlite_pragmas(dbapi_conn, connection_record):
-    """Set SQLite pragmas on every new connection."""
+    """Set SQLite pragmas on every new connection.
+
+    journal_mode is intentionally NOT forced. It is a per-file setting
+    persisted in the SQLite header; pinning it on every connect blocks
+    operators from picking a non-WAL mode (e.g. DELETE) when the database
+    file lives on a Docker bind-mount, where WAL's shared-memory page
+    cannot cross the host/VM file-sharing boundary cleanly and produces
+    intermittent ``disk I/O error`` (SQLITE_IOERR_*) failures. Operators
+    pick a mode once with
+    ``sqlite3 voitta.db 'PRAGMA journal_mode = DELETE;'`` and it sticks.
+    """
     cursor = dbapi_conn.cursor()
-    cursor.execute("PRAGMA journal_mode=WAL")
     cursor.execute("PRAGMA busy_timeout=30000")
     cursor.close()
 
@@ -206,9 +215,19 @@ def _discover_docker_folders(engine: Engine) -> None:
                     logger.info("Removing stale Docker filesystem entry (has child sources): %s", source.folder_path)
                     session.delete(source)
 
-        # Mark remaining root-level entries as Docker-managed
+        # Clear is_docker_managed on non-filesystem sources. Only filesystem
+        # sources can correspond to Docker volume mounts; remote sync sources
+        # (github, sharepoint, jira, etc.) happen to live under root_path
+        # because that's where their synced files land, but they are not
+        # Docker-managed and must remain user-deletable.
         for source in all_sources:
-            if source.folder_path in root_folder_names:
+            if source.source_type != "filesystem" and source.is_docker_managed:
+                source.is_docker_managed = False
+
+        # Mark remaining filesystem root-level entries as Docker-managed.
+        for source in all_sources:
+            if (source.source_type == "filesystem"
+                    and source.folder_path in root_folder_names):
                 source.is_docker_managed = True
 
         session.commit()


### PR DESCRIPTION
## Summary

Two tiny DB-init fixes that surfaced during manual testing of the
llm-tldr companion indexing (PRs #31, #32). Bundled because both block
the same test path and both touch `src/voitta/db/database.py`.

### 1. Stop forcing `PRAGMA journal_mode=WAL` on every connect

SQLite WAL relies on a shared-memory page (`-shm`) that doesn't cross
the host/VM file-sharing boundary cleanly on Docker Desktop, Rancher
Desktop, OrbStack, etc. on macOS. Repeated container restarts produce
intermittent `sqlite3.OperationalError: disk I/O error` on otherwise
healthy DB files (`PRAGMA integrity_check;` returns `ok`).

`journal_mode` is persisted in the SQLite file header, so the
existing `cursor.execute("PRAGMA journal_mode=WAL")` on every connect
blocked operators from picking a non-WAL mode (e.g. DELETE) for their
bind-mount setup — the next connection just flipped it back to WAL.

Drop the line. Operators pick a mode once with:

```
sqlite3 voitta.db "PRAGMA journal_mode = DELETE;"
```

…and it sticks across container restarts. Default behavior for fresh
DBs is SQLite's own default (rollback / DELETE), which is the safe
choice for bind-mounted setups.

### 2. Stop marking non-filesystem sync sources as Docker-managed

`_discover_docker_folders` marked any source whose `folder_path`
matched a top-level dir under `VOITTA_ROOT_PATH` as
`is_docker_managed=True`, **regardless of `source_type`**.

Effect: a `github` / `sharepoint` / `jira` / etc. source whose synced
files happen to live under `root_path/<folder_path>/` got the flag
set on the next container start, after which the delete handler in
`folders.py` refused to remove the source with:

> This folder is managed via Docker volume mounts and cannot be deleted

Only filesystem sources can be Docker volume mounts. Two changes:

- Guard the marking loop on `source_type == "filesystem"`.
- Defensively clear `is_docker_managed` on any non-filesystem source
  that was mis-flagged by the old logic so existing rows recover on
  next container start.

## Test plan

- [ ] Restart container against an existing DB. Confirm
  `sqlite3 voitta.db "PRAGMA journal_mode;"` reflects whatever the
  file header has (not forced back to `wal` if you set `delete`).
- [ ] Confirm that a Git-source folder whose name matches a
  `root_path/<name>/` dir is no longer marked Docker-managed and can
  be deleted from the UI.
- [ ] Confirm existing filesystem-source folders that ARE genuine
  Docker volume mounts remain `is_docker_managed=True` and still
  refuse delete via UI.

Refs: #15
