### PR TITLE
Phase 2.7: Protect llm-tldr companion chunks from orphan-cleanup purge

### DIFF
--- a/src/voitta/services/vector_store.py
+++ b/src/voitta/services/vector_store.py
@@ -528,7 +528,15 @@ class VectorStoreService:
         return count
 
     def get_file_paths_by_index_folder(self, index_folder: str) -> set[str]:
-        """Return all unique file_path values in Qdrant for a given index_folder."""
+        """Return all unique file_path values in Qdrant for a given index_folder.
+
+        Excludes companion chunks (chunks where ``source_type`` is set, e.g.
+        ``llm-tldr-analysis``). Companion chunks have synthetic ``file_path``
+        values (e.g. ``llm-tldr://...``) that do not appear in the
+        ``IndexedFile`` table, and including them here would make the
+        IndexingService.sync_folder orphan-cleanup pass delete every
+        companion chunk on every sync.
+        """
         file_paths: set[str] = set()
         offset = None
         while True:
@@ -539,8 +547,11 @@ class VectorStoreService:
                         qmodels.FieldCondition(
                             key="index_folder",
                             match=qmodels.MatchValue(value=index_folder),
-                        )
-                    ]
+                        ),
+                        qmodels.IsEmptyCondition(
+                            is_empty=qmodels.PayloadField(key="source_type"),
+                        ),
+                    ],
                 ),
                 limit=1000,
                 offset=offset,


### PR DESCRIPTION
## Summary

Latent bug in PR #31 / #32 (Phase 1 + Phase 2 of #15). The
`IndexingService.sync_folder` orphan-cleanup pass was deleting every
llm-tldr companion chunk on every sync, defeating the incremental
reindex and leaving zero analysis chunks in Qdrant.

### Mechanism

`IndexingService.sync_folder` (`indexing.py:886`) calls
`VectorStoreService.get_file_paths_by_index_folder(folder)` to enumerate
all `file_path` values currently in Qdrant for the folder, then diffs
against the `IndexedFile` SQLite table; anything in Qdrant but not in
SQLite is considered an "orphan" (renamed/moved/deleted source file) and
gets purged.

llm-tldr companion chunks live in Qdrant under synthetic
`file_path = "llm-tldr://<folder>/<rel-source-file>"` and are tracked in
a separate SQLite table (`LlmTldrIndexedFile`) — not `IndexedFile`. With
the unfiltered scroll they all looked like orphans and got deleted.

Observed in manual test of `feature/llm-tldr-integration` on
`voitta-rag` itself: 70 rows inserted into `LlmTldrIndexedFile` at sync
time, immediately followed by 70 corresponding "Purged N orphan chunks
from Qdrant: llm-tldr://..." lines in `logs/app.log`.

### Fix

`get_file_paths_by_index_folder` now adds an `IsEmptyCondition` on
`source_type` so only chunks without `source_type` (i.e., regular
code/document chunks) are returned. Companion chunks are
indistinguishable from the caller's perspective.

## Test plan

- [ ] Sync a Git source with `gh_llm_tldr=true`.
- [ ] `select count(*) from llm_tldr_indexed_files where folder_path = '<folder>';` returns N > 0 after sync.
- [ ] In Qdrant: scroll for `source_type = "llm-tldr-analysis"` and `folder_path = "<folder>"` returns N companion chunks (not zero).
- [ ] Sync again. Count stays at N. No "Purged ... llm-tldr://..." lines in `logs/app.log`.
- [ ] Regular orphan cleanup still works: rename a tracked source file upstream + sync; the old path's chunks should be purged as before.

Refs: #15
