### PR TITLE
Phase 2.8: Per-file commit in llm-tldr indexer to avoid SQLite lock

### DIFF
--- a/src/voitta/services/llm_tldr_indexer.py
+++ b/src/voitta/services/llm_tldr_indexer.py
@@ -119,7 +119,7 @@ class LlmTldrIndexer:
                     LlmTldrIndexedFile.folder_path == folder_path
                 )
             )
-            db.flush()
+            db.commit()
 
         # Snapshot known state from the DB.
         existing_rows = db.execute(
@@ -148,11 +148,18 @@ class LlmTldrIndexer:
         )
 
         # Removed files: in DB, not on disk → delete their chunks + rows.
+        # Commit per file to keep each SQLite write transaction tiny. With
+        # journal_mode=DELETE the SQLite file lock is held for the whole
+        # transaction, blocking any concurrent writer (e.g. the FastAPI
+        # request handler that triggered the sync). A single transaction
+        # spanning the entire indexer pass routinely exceeds busy_timeout
+        # and surfaces as "database is locked" after partial progress.
         removed = set(existing_by_rel) - set(current_hashes)
         for rel in removed:
             self.vector_store.delete_by_folder_and_related_file(folder_path, rel)
             db.delete(existing_by_rel[rel])
             stats["files_removed"] += 1
+            db.commit()
 
         # New / changed files: extract, store, upsert row.
         for rel, source_hash in current_hashes.items():
@@ -210,8 +217,8 @@ class LlmTldrIndexer:
                 existing_row.updated_at = datetime.now(timezone.utc)
                 stats["files_updated"] += 1
             stats["chunks_stored"] += chunks_stored
+            db.commit()
 
-        db.commit()
         logger.info("llm-tldr: indexing complete for %s: %s", folder_path, stats)
         return stats
 


### PR DESCRIPTION
## Summary

Phase 2 (#32) accumulated all `LlmTldrIndexedFile` inserts and updates in a single SQLAlchemy session and committed at the end. After PR #34 switched the operator-recommended journal mode to `delete`, the write transaction held the SQLite file lock for the entire indexer pass — minutes on a ~70 source-file repo — and blocked the FastAPI request handler that triggered the sync.

Symptom (manual test of `vrag-test-4` on `feature/llm-tldr-integration`):

```
sqlalchemy.exc.OperationalError: (sqlite3.OperationalError) database is locked
[SQL: INSERT INTO llm_tldr_indexed_files (...) VALUES (?, ?, ?, ?, ?, ?) RETURNING id]
[parameters: ('vrag-test-4', 'branches/master/tests/conftest.py', ...)]
```

`sync_status` ended `error`, zero rows persisted, sync visibly "completed" after ~30s busy_timeout.

## Fix

`db.commit()` per file inside both loops (removed-files and new/changed-files), and one more after the `force=True` bulk delete. The embedding + Qdrant store still happens before the commit, so the lock window shrinks from "duration of the entire indexer pass" to "single SQLAlchemy round-trip per file".

## Test plan

- [ ] Sync a fresh source with `gh_llm_tldr=true`. Completes without "database is locked".
- [ ] `select count(*) from llm_tldr_indexed_files where folder_path = '<folder>';` grows monotonically during sync (not zero-then-N-at-end).
- [ ] `sync_status` ends `synced`, not `error`.
- [ ] Subsequent idempotent re-sync produces zero new rows and no errors.

Refs: #15
