### PR TITLE
Phase 2.9: Release async session during connector.sync() (SQLite lock fix)

### DIFF
--- a/src/voitta/api/routes/sync.py
+++ b/src/voitta/api/routes/sync.py
@@ -995,10 +995,20 @@ async def delete_sync_source(path: str, user: CurrentUser, db: DB):
 
 
 async def _run_sync(folder_path: str):
-    """Run sync in background."""
+    """Run sync in background.
+
+    The async DB session is held only across short read / write windows.
+    The long-running ``connector.sync()`` call runs with NO async session
+    open, so the shared file-lock from a pending read transaction does
+    not block sync-worker sub-tasks (e.g. the llm-tldr indexer running in
+    a thread via a sync ``Session``) under journal_mode=DELETE. Under WAL
+    a long-lived read txn was harmless; under DELETE it serialises every
+    other writer.
+    """
     from ...services.filesystem import FilesystemService
     from ...services.watcher import file_watcher
 
+    # Step 1: load source, detach, close session.
     async with get_db_context() as db:
         result = await db.execute(
             select(FolderSyncSource).where(FolderSyncSource.folder_path == folder_path)
@@ -1006,73 +1016,87 @@ async def _run_sync(folder_path: str):
         source = result.scalar_one_or_none()
         if not source:
             return
+        db.expunge(source)
 
-        # Suppress file watcher events for this folder during sync
-        file_watcher.suppress_path(folder_path)
-        try:
-            connector = get_connector(source.source_type)
-            from ...services.filesystem import get_filesystem_service as _get_fs
-            fs = _get_fs()
-            await connector.sync(source, fs)
+    file_watcher.suppress_path(folder_path)
+    final_status = "synced"
+    final_error: str | None = None
+    last_synced_at = None
 
-            # Post-sync: fetch Teams meeting transcripts for SharePoint sources
-            if source.source_type == "sharepoint":
-                try:
-                    from ...services.sync.teams_transcripts import fetch_transcripts_for_folder
-                    token = await connector._get_access_token(source)
-                    count = await fetch_transcripts_for_folder(source, fs, token)
-                    if count:
-                        logger.info("Fetched %d transcript(s) for %s", count, folder_path)
-                except Exception as e:
-                    logger.warning("Transcript fetch failed for %s: %s", folder_path, e)
+    try:
+        connector = get_connector(source.source_type)
+        from ...services.filesystem import get_filesystem_service as _get_fs
+        fs = _get_fs()
+        await connector.sync(source, fs)
 
-            # Post-sync: reconcile index with new disk state
+        # Post-sync: fetch Teams meeting transcripts for SharePoint sources
+        if source.source_type == "sharepoint":
             try:
-                from ...services.indexing import get_indexing_service
-                from sqlalchemy.orm import Session as SyncSession
-
-                indexing_service = get_indexing_service()
-                with SyncSession(get_sync_engine()) as sync_db:
-                    # Find all indexed/pending subfolders under this folder
-                    result = sync_db.execute(
-                        select(FolderIndexStatus).where(
-                            FolderIndexStatus.folder_path.startswith(folder_path),
-                            FolderIndexStatus.status.in_(["indexed", "pending"]),
-                        )
-                    )
-                    for idx_status in result.scalars().all():
-                        added, removed, _ = indexing_service.sync_folder(
-                            idx_status.folder_path, sync_db
-                        )
-                        if removed:
-                            logger.info(
-                                "Post-sync cleanup [%s]: removed %d stale files",
-                                idx_status.folder_path,
-                                removed,
-                            )
-                    sync_db.commit()
+                from ...services.sync.teams_transcripts import fetch_transcripts_for_folder
+                token = await connector._get_access_token(source)
+                count = await fetch_transcripts_for_folder(source, fs, token)
+                if count:
+                    logger.info("Fetched %d transcript(s) for %s", count, folder_path)
             except Exception as e:
-                logger.warning(
-                    "Post-sync index reconciliation failed for %s: %s",
-                    folder_path,
-                    e,
+                logger.warning("Transcript fetch failed for %s: %s", folder_path, e)
+
+        # Post-sync: reconcile index with new disk state. Uses its own
+        # short sync Session; no async session is open here.
+        try:
+            from ...services.indexing import get_indexing_service
+            from sqlalchemy.orm import Session as SyncSession
+
+            indexing_service = get_indexing_service()
+            with SyncSession(get_sync_engine()) as sync_db:
+                result = sync_db.execute(
+                    select(FolderIndexStatus).where(
+                        FolderIndexStatus.folder_path.startswith(folder_path),
+                        FolderIndexStatus.status.in_(["indexed", "pending"]),
+                    )
                 )
-
-            source.sync_status = "synced"
-            source.sync_error = None
-            source.last_synced_at = utc_now()
+                for idx_status in result.scalars().all():
+                    added, removed, _ = indexing_service.sync_folder(
+                        idx_status.folder_path, sync_db
+                    )
+                    if removed:
+                        logger.info(
+                            "Post-sync cleanup [%s]: removed %d stale files",
+                            idx_status.folder_path,
+                            removed,
+                        )
+                sync_db.commit()
         except Exception as e:
-            logger.exception("Sync failed for %s", folder_path)
-            source.sync_status = "error"
-            source.sync_error = str(e)
-        finally:
-            file_watcher.unsuppress_path(folder_path)
+            logger.warning(
+                "Post-sync index reconciliation failed for %s: %s",
+                folder_path,
+                e,
+            )
 
-        # Broadcast sync status change via WebSocket
-        await file_watcher.broadcast({
-            "type": "sync_status",
-            "path": folder_path,
-            "sync_status": source.sync_status,
-            "sync_error": source.sync_error,
-            "last_synced_at": source.last_synced_at.isoformat() if source.last_synced_at else None,
-        })
+        last_synced_at = utc_now()
+    except Exception as e:
+        logger.exception("Sync failed for %s", folder_path)
+        final_status = "error"
+        final_error = str(e)
+    finally:
+        file_watcher.unsuppress_path(folder_path)
+
+    # Step 2: write final status in a fresh short session.
+    async with get_db_context() as db:
+        result = await db.execute(
+            select(FolderSyncSource).where(FolderSyncSource.folder_path == folder_path)
+        )
+        persisted = result.scalar_one_or_none()
+        if persisted is not None:
+            persisted.sync_status = final_status
+            persisted.sync_error = final_error
+            if final_status == "synced":
+                persisted.last_synced_at = last_synced_at
+            await db.commit()
+
+    await file_watcher.broadcast({
+        "type": "sync_status",
+        "path": folder_path,
+        "sync_status": final_status,
+        "sync_error": final_error,
+        "last_synced_at": last_synced_at.isoformat() if last_synced_at else None,
+    })


### PR DESCRIPTION
## Summary

Final piece to unblock manual testing of `feature/llm-tldr-integration` on a Docker bind-mounted SQLite DB. The background sync worker (`_run_sync` in `routes/sync.py`) held one async SQLAlchemy session open across the entire sync flow — load source, run connector, run post-sync hooks, update final status. Under WAL that pattern was harmless; under `journal_mode = DELETE` (#34) the initial `SELECT` keeps a shared file-lock pinned for the duration of `connector.sync()`, blocking every other writer.

The Phase 2 llm-tldr indexer (#32) runs inside `connector.sync()` via `asyncio.to_thread` with a **separate sync `Session`**. With the outer shared lock held, its first `INSERT INTO llm_tldr_indexed_files` waited the full `busy_timeout=30000` and surfaced as `database is locked`, even after PR #36's per-file commits shrank its own transaction window to a single row.

## Fix

Split `_run_sync` into three short DB windows:

1. Open an async session, load source row, `db.expunge(source)`, close.
2. Run `connector.sync()` + post-sync hooks with **no async session open**. The detached `FolderSyncSource` has no relationships, so reading its column attrs is safe.
3. Open a second short async session, re-load the row by `folder_path`, write final status (`synced` / `error`), commit.
4. Broadcast the WebSocket event from local vars, not the ORM object.

The post-sync index reconciliation and the llm-tldr indexer now acquire write locks immediately because nothing else holds the file.

## Test plan

- [ ] Sync a Git source with `gh_llm_tldr=true` on a bind-mounted SQLite DB in `journal_mode=delete`.
  Expected: completes without `database is locked`. `llm_tldr_indexed_files` count > 0 at end. `sync_status` = `synced`.
- [ ] Subsequent idempotent re-sync: zero new tldr rows, zero errors.
- [ ] Non-Git source types still work end-to-end (filesystem, sharepoint).
- [ ] Confirm `last_synced_at` updates on success, `sync_error` populates on failure.

Refs: #15
