### PR TITLE
Phase 3: Rich call-graph payload + function-level chunking

### DIFF
--- a/src/voitta/services/llm_tldr_indexer.py
+++ b/src/voitta/services/llm_tldr_indexer.py
@@ -12,7 +12,6 @@ chunk / store cycle. Set ``force=True`` to wipe and re-extract everything
 """
 
 import hashlib
-import json
 import logging
 from datetime import datetime, timezone
 from pathlib import Path
@@ -176,8 +175,8 @@ class LlmTldrIndexer:
                 stats["files_skipped"] += 1
                 continue
 
-            text = _render_extract(rel, info)
-            if not text.strip():
+            parts = _build_chunk_parts(rel, info)
+            if not parts:
                 stats["files_skipped"] += 1
                 continue
 
@@ -188,8 +187,8 @@ class LlmTldrIndexer:
                 )
 
             try:
-                chunks_stored = self._store_chunks(
-                    text=text,
+                chunks_stored = self._store_chunk_parts(
+                    parts=parts,
                     related_file=rel,
                     folder_path=folder_path,
                     index_folder=index_folder,
@@ -222,42 +221,58 @@ class LlmTldrIndexer:
         logger.info("llm-tldr: indexing complete for %s: %s", folder_path, stats)
         return stats
 
-    def _store_chunks(
+    def _store_chunk_parts(
         self,
-        text: str,
+        parts: list[tuple[str, dict]],
         related_file: str,
         folder_path: str,
         index_folder: str,
     ) -> int:
-        chunks = self.chunker.chunk_text(text)
-        if not chunks:
+        """Embed and store pre-built (text, payload-overrides) tuples.
+
+        Each part becomes one Qdrant point. The text body goes through
+        the dense+sparse embedder; ``payload_overrides`` contains the
+        Phase 3 call-graph fields specific to that chunk (function name,
+        callers/callees, etc.).
+        """
+        if not parts:
             return 0
 
-        texts = [c.text for c in chunks]
+        texts = [text for text, _ in parts]
         embeddings = self.embedder.embed_texts(texts)
         sparse_vectors = self.sparse_embedder.embed_texts(texts)
 
         indexed_at = datetime.now(timezone.utc).isoformat()
         synthetic_path = f"llm-tldr://{folder_path}/{related_file}"
         chunk_data = []
-        for chunk, embedding in zip(chunks, embeddings):
+        for idx, ((text, payload_overrides), embedding) in enumerate(
+            zip(parts, embeddings)
+        ):
             metadata = ChunkMetadata(
                 file_path=synthetic_path,
                 folder_path=folder_path,
                 index_folder=index_folder,
                 file_name=Path(related_file).name + ".tldr.md",
-                chunk_index=chunk.index,
-                total_chunks=len(chunks),
-                start_char=chunk.start_char,
-                end_char=chunk.end_char,
+                chunk_index=idx,
+                total_chunks=len(parts),
+                start_char=0,
+                end_char=len(text),
                 indexed_at=indexed_at,
                 source_type=SOURCE_TYPE,
                 related_file=related_file,
+                tldr_chunk_kind=payload_overrides.get("tldr_chunk_kind"),
+                tldr_function_name=payload_overrides.get("tldr_function_name"),
+                tldr_class_name=payload_overrides.get("tldr_class_name"),
+                tldr_callees=payload_overrides.get("tldr_callees"),
+                tldr_callers=payload_overrides.get("tldr_callers"),
+                tldr_caller_count=payload_overrides.get("tldr_caller_count"),
+                tldr_callee_count=payload_overrides.get("tldr_callee_count"),
+                tldr_imports=payload_overrides.get("tldr_imports"),
             )
-            chunk_data.append((chunk.text, embedding, metadata))
+            chunk_data.append((text, embedding, metadata))
 
         self.vector_store.store_chunks(chunk_data, sparse_vectors=sparse_vectors)
-        return len(chunks)
+        return len(chunk_data)
 
 
 def _collect_source_files(repo_dir: Path) -> list[Path]:
@@ -278,101 +293,152 @@ def _collect_source_files(repo_dir: Path) -> list[Path]:
     return files
 
 
-def _render_extract(rel_path: str, info: dict) -> str:
-    """Render an llm-tldr extract_file dict as markdown text for chunking."""
-    lines: list[str] = []
-    lines.append(f"# llm-tldr analysis: {rel_path}")
+# Bumped whenever the analysis chunk format changes. Mixed into
+# _hash_file so existing rows whose content_hash was computed under a
+# previous format will mismatch and trigger a re-extract on the next
+# sync. v1: file-level rendered markdown (Phase 1+2). v3: per-function
+# chunks + call-graph payload (Phase 3).
+ANALYSIS_FORMAT_VERSION = "v3"
+
+
+def _build_chunk_parts(rel_path: str, info: dict) -> list[tuple[str, dict]]:
+    """Build (text, payload-overrides) tuples for one source file.
+
+    Emits one file_overview chunk plus one function chunk per top-level
+    function and per class method. Each function chunk carries the
+    structured call-graph payload (callers, callees, counts, imports)
+    needed for Phase 3 filtered searches.
+    """
+    parts: list[tuple[str, dict]] = []
+
+    # File overview
+    imports_list = _normalize_imports(info.get("imports") or [])
     lang = info.get("language") or "unknown"
-    lines.append(f"Language: {lang}")
+    overview_lines = [f"# llm-tldr file overview: {rel_path}"]
+    overview_lines.append(f"Language: {lang}")
     docstring = info.get("docstring")
     if docstring:
-        lines.append("")
-        lines.append("## Module docstring")
-        lines.append(docstring.strip())
-
-    imports = info.get("imports") or []
-    if imports:
-        lines.append("")
-        lines.append("## Imports")
-        for imp in imports:
-            lines.append(f"- {_render_import(imp)}")
-
-    functions = info.get("functions") or []
-    if functions:
-        lines.append("")
-        lines.append("## Functions")
-        for fn in functions:
-            lines.append(_render_function(fn))
-
-    classes = info.get("classes") or []
-    if classes:
-        lines.append("")
-        lines.append("## Classes")
-        for cls in classes:
-            lines.append(_render_class(cls))
+        overview_lines.append("")
+        overview_lines.append(docstring.strip())
+    if imports_list:
+        overview_lines.append("")
+        overview_lines.append("Imports: " + ", ".join(imports_list))
+    class_names = [
+        c.get("name") for c in (info.get("classes") or [])
+        if isinstance(c, dict) and c.get("name")
+    ]
+    if class_names:
+        overview_lines.append("Classes: " + ", ".join(class_names))
+    func_names = [
+        f.get("name") for f in (info.get("functions") or [])
+        if isinstance(f, dict) and f.get("name")
+    ]
+    if func_names:
+        overview_lines.append("Top-level functions: " + ", ".join(func_names))
+    parts.append((
+        "\n".join(overview_lines),
+        {
+            "tldr_chunk_kind": "file_overview",
+            "tldr_imports": imports_list or None,
+        },
+    ))
 
     call_graph = info.get("call_graph") or {}
-    if call_graph:
-        lines.append("")
-        lines.append("## Call graph")
-        lines.append("```json")
-        lines.append(json.dumps(call_graph, indent=2, default=str))
-        lines.append("```")
+    calls_map = call_graph.get("calls") or {}
+    called_by_map = call_graph.get("called_by") or {}
 
-    return "\n".join(lines)
+    # Top-level functions
+    for fn in info.get("functions") or []:
+        part = _build_function_part(
+            fn, class_name=None, rel_path=rel_path,
+            imports_list=imports_list,
+            calls_map=calls_map, called_by_map=called_by_map,
+        )
+        if part is not None:
+            parts.append(part)
+
+    # Class methods
+    for cls in info.get("classes") or []:
+        if not isinstance(cls, dict):
+            continue
+        cls_name = cls.get("name") or "(anonymous)"
+        for method in cls.get("methods") or []:
+            part = _build_function_part(
+                method, class_name=cls_name, rel_path=rel_path,
+                imports_list=imports_list,
+                calls_map=calls_map, called_by_map=called_by_map,
+            )
+            if part is not None:
+                parts.append(part)
+
+    return parts
 
 
-def _render_import(imp) -> str:
-    if isinstance(imp, dict):
-        module = imp.get("module") or imp.get("name") or ""
-        names = imp.get("names") or []
-        if names:
-            return f"{module} ({', '.join(map(str, names))})"
-        return str(module)
-    return str(imp)
-
-
-def _render_function(fn) -> str:
+def _build_function_part(
+    fn,
+    class_name: str | None,
+    rel_path: str,
+    imports_list: list[str],
+    calls_map: dict,
+    called_by_map: dict,
+) -> tuple[str, dict] | None:
     if not isinstance(fn, dict):
-        return f"- {fn}"
-    parts: list[str] = []
-    sig = fn.get("signature") or fn.get("name") or ""
-    parts.append(f"### {sig}")
-    if fn.get("docstring"):
-        parts.append(fn["docstring"].strip())
-    calls = fn.get("calls") or []
-    if calls:
-        parts.append(f"Calls: {', '.join(map(str, calls))}")
-    called_by = fn.get("called_by") or []
-    if called_by:
-        parts.append(f"Called by: {', '.join(map(str, called_by))}")
-    complexity = fn.get("complexity")
-    if complexity is not None:
-        parts.append(f"Cyclomatic complexity: {complexity}")
-    return "\n".join(parts)
+        return None
+    name = fn.get("name") or ""
+    if not name:
+        return None
+    key = f"{class_name}.{name}" if class_name else name
+    callees = list(calls_map.get(key) or [])
+    callers = list(called_by_map.get(key) or [])
+    sig = fn.get("signature") or name
+    lines = [f"# llm-tldr function: {key} (in {rel_path})"]
+    lines.append(f"Signature: {sig}")
+    if fn.get("is_async"):
+        lines.append("Async: True")
+    docstring = fn.get("docstring")
+    if docstring:
+        lines.append("")
+        lines.append(docstring.strip())
+    if callees:
+        lines.append("")
+        lines.append(f"Calls: {', '.join(callees)}")
+    if callers:
+        lines.append(f"Called by: {', '.join(callers)}")
+    text = "\n".join(lines)
+    payload = {
+        "tldr_chunk_kind": "function",
+        "tldr_function_name": name,
+        "tldr_class_name": class_name,
+        "tldr_callees": callees or None,
+        "tldr_callers": callers or None,
+        "tldr_caller_count": len(callers),
+        "tldr_callee_count": len(callees),
+        "tldr_imports": imports_list or None,
+    }
+    return (text, payload)
 
 
-def _render_class(cls) -> str:
-    if not isinstance(cls, dict):
-        return f"- {cls}"
-    parts: list[str] = []
-    name = cls.get("name") or "(anonymous)"
-    bases = cls.get("bases") or cls.get("base_classes") or []
-    header = f"### class {name}"
-    if bases:
-        header += f"({', '.join(map(str, bases))})"
-    parts.append(header)
-    if cls.get("docstring"):
-        parts.append(cls["docstring"].strip())
-    methods = cls.get("methods") or []
-    for m in methods:
-        parts.append(_render_function(m))
-    return "\n".join(parts)
+def _normalize_imports(imports) -> list[str]:
+    """Reduce llm-tldr's import entries to a flat list of module names."""
+    out: list[str] = []
+    for imp in imports:
+        if isinstance(imp, dict):
+            mod = imp.get("module") or imp.get("name")
+            if mod:
+                out.append(str(mod))
+        elif imp:
+            out.append(str(imp))
+    return out
 
 
 def _hash_file(path: Path) -> str:
-    """SHA-256 hash of the file's raw bytes."""
+    """SHA-256 hash of the file's raw bytes, salted with the analysis
+    format version. A format-version bump invalidates all stored hashes
+    so the next sync re-extracts every file into the new format.
+    """
     sha = hashlib.sha256()
+    sha.update(ANALYSIS_FORMAT_VERSION.encode("ascii"))
+    sha.update(b"\0")
     with open(path, "rb") as f:
         for chunk in iter(lambda: f.read(8192), b""):
             sha.update(chunk)

--- a/src/voitta/services/vector_store.py
+++ b/src/voitta/services/vector_store.py
@@ -45,6 +45,17 @@ class ChunkMetadata:
     # analysis was derived from.
     source_type: str | None = None
     related_file: str | None = None
+    # llm-tldr Phase 3 — structured call-graph payload (only set on
+    # source_type == "llm-tldr-analysis" chunks). Lets Qdrant filters
+    # answer "functions with >5 callers" / "functions importing X".
+    tldr_chunk_kind: str | None = None  # "function" | "file_overview"
+    tldr_function_name: str | None = None
+    tldr_class_name: str | None = None  # for methods; None for free functions
+    tldr_callees: list[str] | None = None
+    tldr_callers: list[str] | None = None
+    tldr_caller_count: int | None = None
+    tldr_callee_count: int | None = None
+    tldr_imports: list[str] | None = None  # file-level imports, attached to each function chunk
 
 
 @dataclass
@@ -91,6 +102,7 @@ class VectorStoreService:
             self._ensure_acl_index()
             self._ensure_source_url_index()
             self._ensure_companion_chunk_indexes()
+            self._ensure_tldr_callgraph_indexes()
         except (UnexpectedResponse, Exception):
             logger.info(f"Creating collection '{self.collection_name}'")
             self._client.create_collection(
@@ -106,13 +118,13 @@ class VectorStoreService:
                 },
             )
             # Create payload indexes for efficient filtering
-            for field in ("file_path", "folder_path", "index_folder", "allowed_users", "source_url", "source_type", "related_file"):
+            for field in ("file_path", "folder_path", "index_folder", "allowed_users", "source_url", "source_type", "related_file", "tldr_chunk_kind", "tldr_function_name", "tldr_class_name", "tldr_callees", "tldr_callers", "tldr_imports"):
                 self._client.create_payload_index(
                     collection_name=self.collection_name,
                     field_name=field,
                     field_schema=qmodels.PayloadSchemaType.KEYWORD,
                 )
-            for field in ("source_created_at", "source_modified_at"):
+            for field in ("source_created_at", "source_modified_at", "tldr_caller_count", "tldr_callee_count"):
                 self._client.create_payload_index(
                     collection_name=self.collection_name,
                     field_name=field,
@@ -182,6 +194,45 @@ class VectorStoreService:
                     logger.info(f"Created index for '{field}' on '{self.collection_name}'")
         except Exception as e:
             logger.warning(f"Failed to ensure companion-chunk indexes: {e}")
+
+    def _ensure_tldr_callgraph_indexes(self) -> None:
+        """Create payload indexes for llm-tldr Phase 3 call-graph fields.
+
+        KEYWORD indexes for kind / function / class / callees / callers /
+        imports (so filters can do MatchAny). INTEGER indexes for caller
+        and callee counts (so filters can do Range, e.g. "functions with
+        >5 callers").
+        """
+        try:
+            info = self._client.get_collection(self.collection_name)
+            existing = set(info.payload_schema.keys()) if info.payload_schema else set()
+            keyword_fields = (
+                "tldr_chunk_kind",
+                "tldr_function_name",
+                "tldr_class_name",
+                "tldr_callees",
+                "tldr_callers",
+                "tldr_imports",
+            )
+            integer_fields = ("tldr_caller_count", "tldr_callee_count")
+            for field in keyword_fields:
+                if field not in existing:
+                    self._client.create_payload_index(
+                        collection_name=self.collection_name,
+                        field_name=field,
+                        field_schema=qmodels.PayloadSchemaType.KEYWORD,
+                    )
+                    logger.info(f"Created index for '{field}' on '{self.collection_name}'")
+            for field in integer_fields:
+                if field not in existing:
+                    self._client.create_payload_index(
+                        collection_name=self.collection_name,
+                        field_name=field,
+                        field_schema=qmodels.PayloadSchemaType.INTEGER,
+                    )
+                    logger.info(f"Created index for '{field}' on '{self.collection_name}'")
+        except Exception as e:
+            logger.warning(f"Failed to ensure tldr call-graph indexes: {e}")
 
     def delete_by_folder_and_related_file(
         self, folder_path: str, related_file: str,
@@ -380,6 +431,23 @@ class VectorStoreService:
                 payload["source_type"] = metadata.source_type
             if metadata.related_file is not None:
                 payload["related_file"] = metadata.related_file
+            # llm-tldr Phase 3 — call-graph payload
+            if metadata.tldr_chunk_kind is not None:
+                payload["tldr_chunk_kind"] = metadata.tldr_chunk_kind
+            if metadata.tldr_function_name is not None:
+                payload["tldr_function_name"] = metadata.tldr_function_name
+            if metadata.tldr_class_name is not None:
+                payload["tldr_class_name"] = metadata.tldr_class_name
+            if metadata.tldr_callees is not None:
+                payload["tldr_callees"] = metadata.tldr_callees
+            if metadata.tldr_callers is not None:
+                payload["tldr_callers"] = metadata.tldr_callers
+            if metadata.tldr_caller_count is not None:
+                payload["tldr_caller_count"] = metadata.tldr_caller_count
+            if metadata.tldr_callee_count is not None:
+                payload["tldr_callee_count"] = metadata.tldr_callee_count
+            if metadata.tldr_imports is not None:
+                payload["tldr_imports"] = metadata.tldr_imports
 
             # Build vector: unnamed dense + optional sparse
             if sparse_vectors and idx < len(sparse_vectors):
@@ -660,6 +728,14 @@ class VectorStoreService:
                 source_url=payload.get("source_url"),
                 source_type=payload.get("source_type"),
                 related_file=payload.get("related_file"),
+                tldr_chunk_kind=payload.get("tldr_chunk_kind"),
+                tldr_function_name=payload.get("tldr_function_name"),
+                tldr_class_name=payload.get("tldr_class_name"),
+                tldr_callees=payload.get("tldr_callees"),
+                tldr_callers=payload.get("tldr_callers"),
+                tldr_caller_count=payload.get("tldr_caller_count"),
+                tldr_callee_count=payload.get("tldr_callee_count"),
+                tldr_imports=payload.get("tldr_imports"),
             ),
             score=result.score,
         )


### PR DESCRIPTION
## Summary

Phase 3 of #15. llm-tldr companion chunks now carry the call graph as structured Qdrant payload, enabling filtered searches that approximate a GitNexus-style knowledge graph without a separate graph DB.

### Chunking change

Before: one rendered markdown blob per file, recursively chunked.
After:
- 1 `file_overview` chunk per source file (module docstring + imports + class/function name lists)
- 1 chunk per top-level function and per class method, with signature, docstring, callers, callees

### New ChunkMetadata payload (Phase 3 only)

Added to `ChunkMetadata` and round-tripped through `_result_to_chunk`:

| Field | Type | Index | Purpose |
|---|---|---|---|
| `tldr_chunk_kind` | KEYWORD | yes | `"function"` or `"file_overview"` |
| `tldr_function_name` | KEYWORD | yes | filter / display |
| `tldr_class_name` | KEYWORD | yes | filter / display (None for free fns) |
| `tldr_callees` | KEYWORD multivalued | yes | "things this fn calls" |
| `tldr_callers` | KEYWORD multivalued | yes | "things that call this fn" |
| `tldr_caller_count` | INTEGER | yes | for `Range` filter |
| `tldr_callee_count` | INTEGER | yes | for `Range` filter |
| `tldr_imports` | KEYWORD multivalued | yes | file-level imports, on each chunk |

### Filters enabled

- "functions with >5 callers" — `Range(tldr_caller_count, gte=5)`
- "functions importing module X" — `MatchAny(tldr_imports, [X])`
- "all methods on class Y" — `Match(tldr_class_name, Y)`
- "functions named verify_*" — `Match(tldr_function_name, ...)`

### Out of scope

- Cyclomatic complexity: lives in llm-tldr's separate CFG extractor (a per-function API call). Skipped to keep PoC cost down; can add later if it earns the embedding+storage budget.
- API/MCP surface for these filters: payload is filterable by anyone who builds a Qdrant `Filter`, but no end-user search route exposes the new payload yet. Wire-up is straightforward when there's a use case.

### Migration

A new `ANALYSIS_FORMAT_VERSION = "v3"` constant is mixed into `_hash_file`'s input. Every existing `LlmTldrIndexedFile.content_hash` mismatches on the next sync, so the Phase 2 incremental indexer naturally treats every file as changed and re-extracts under the new format. No manual `force=True` step required.

## Test plan

- [ ] Sync `vrag-test-4` with this branch deployed. Expect every file to be `files_updated`, no errors.
- [ ] Qdrant point count for `source_type=llm-tldr-analysis, folder_path=vrag-test-4` drops to roughly one-per-function (likely 200-400 for voitta-rag, down from 881 file-level chunks).
- [ ] Scroll one chunk: payload includes `tldr_chunk_kind="function"`, `tldr_function_name`, `tldr_callees`, `tldr_callers`, `tldr_caller_count`, `tldr_callee_count`, `tldr_imports`.
- [ ] Qdrant filter `tldr_caller_count >= 3` returns non-empty.
- [ ] Qdrant filter `tldr_imports = "sqlalchemy.orm"` returns only chunks from files importing it.
- [ ] Idempotent re-sync: `files_unchanged = N`, zero new points.

Refs: #15
