### PR TITLE
Phase 3.1: Bump Qdrant client HTTP timeout to 60s

### DIFF
--- a/src/voitta/services/vector_store.py
+++ b/src/voitta/services/vector_store.py
@@ -82,10 +82,21 @@ class VectorStoreService:
 
     @property
     def client(self) -> QdrantClient:
-        """Lazy load the Qdrant client."""
+        """Lazy load the Qdrant client.
+
+        qdrant-client defaults its HTTP timeout to 5 seconds, which is
+        fine for vector search but too tight for filtered ``delete`` /
+        ``count`` against a large collection — payload-index filter
+        compilation alone routinely takes >5s on collections with
+        >1M points. The llm-tldr companion indexer (Phase 2+) issues
+        per-file ``delete`` calls; raising the timeout keeps those
+        within budget without making fast paths any slower.
+        """
         if self._client is None:
             logger.info(f"Connecting to Qdrant at {self.host}:{self.port}")
-            self._client = QdrantClient(host=self.host, port=self.port)
+            self._client = QdrantClient(
+                host=self.host, port=self.port, timeout=60,
+            )
             self._ensure_collection()
         return self._client
 


### PR DESCRIPTION
## Summary

qdrant-client defaults to a **5 second** HTTP timeout, fine for vector search but too tight for filtered `delete` / `count` / `scroll` against large collections. On the test fixture (a Qdrant instance with ~1.9M total points across multiple folders) the Phase 2 llm-tldr per-file delete path times out:

```
qdrant_client.http.exceptions.ResponseHandlingException: timed out
  File ".../llm_tldr_indexer.py", line 185, in index_repo
    self.vector_store.delete_by_folder_and_related_file(...)
  File ".../vector_store.py", line 262, in delete_by_folder_and_related_file
    self.client.delete(...)
```

Sync ends in `sync_error="timed out"` and zero re-extracts happen.

## Fix

Pass `timeout=60` when constructing `QdrantClient`. Fast paths (vector search, point upsert) take well under 1s in practice so the new ceiling never trips them; slow paths (filtered scroll/count/delete on big collections) now have room to finish.

## Test plan

- [ ] On a collection with >1M points, trigger an llm-tldr re-sync (e.g. after a format-version bump like #38). No `timed out` errors. `sync_status` ends `synced`.
- [ ] Search latency unchanged (was already well under 5s, stays well under 60s).
- [ ] Confirm no other Qdrant timeouts surface in `logs/app.log`.

Refs: #15
