### PR TITLE
Phase 4: Git post-commit hook + secret-authed sync endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,7 @@ Useful for teams and individuals who want to:
   - [Round-trip between machines](#round-trip-between-machines)
 - [Advanced](#advanced)
   - [SQLite journal mode on Docker bind-mounts](#sqlite-journal-mode-on-docker-bind-mounts)
+  - [Git post-commit hook](#git-post-commit-hook)
 
 ## Features
 
@@ -500,5 +501,95 @@ sqlite3 voitta.db "PRAGMA journal_mode = WAL;"
 
 See also the [SQLite docs on journal mode](https://www.sqlite.org/pragma.html#pragma_journal_mode)
 and [WAL mode caveats on networked filesystems](https://www.sqlite.org/wal.html#sometimes_queries_return_sqlite_busy_in_wal_mode).
+
+### Git post-commit hook
+
+> **For operators only.** Skip this if your Git sources reindex on a
+> schedule and you don't need fresh data after each commit.
+
+If you have a voitta-rag Git source pointed at a repository you actively
+work on, you can wire a post-commit hook in that repository so every
+local commit immediately triggers a sync (which also re-runs the
+optional `llm-tldr` static analysis from issue [#15](https://github.com/voitta-ai/voitta-rag/issues/15)).
+This keeps the indexed snapshot — both raw code chunks and structural
+analysis chunks — in lockstep with `HEAD` on your machine without
+waiting for the next scheduled sync.
+
+**1. Enable the hook endpoint on the voitta-rag server.**
+
+The hook calls `POST /api/sync/_hook/sync/{folder_path}` which is
+authenticated by a shared secret in the `X-Voitta-Hook-Secret` header,
+not by browser cookie. The route is disabled (returns 403) when the
+secret env var is unset, so this is strictly opt-in.
+
+In your voitta-rag `.env`:
+
+```
+VOITTA_HOOK_SECRET=<choose a long random string>
+```
+
+Restart the container so the new env var is picked up:
+
+```
+docker compose restart voitta-rag
+```
+
+**2. Install the hook in your repo.**
+
+Copy `scripts/git-hooks/post-commit` from this repo into your target
+repo's `.git/hooks/` directory and make it executable:
+
+```
+cp /path/to/voitta-rag/scripts/git-hooks/post-commit \
+   /path/to/my-repo/.git/hooks/post-commit
+chmod +x /path/to/my-repo/.git/hooks/post-commit
+```
+
+If you maintain shared hooks across multiple repos via `core.hooksPath`
+or a tool like [husky](https://typicode.github.io/husky/), drop the
+script there instead.
+
+**3. Tell the hook how to reach your voitta-rag.**
+
+The hook reads three environment variables. Set them in your shell rc
+file (`~/.bashrc`, `~/.zshrc`, etc.) so they're available whenever you
+commit:
+
+```
+export VOITTA_RAG_URL=http://localhost:58000
+export VOITTA_RAG_FOLDER=my-repo              # the voitta-rag folder_path
+export VOITTA_HOOK_SECRET=<same value as on the server>
+```
+
+The hook bails out silently when any of these is unset, so the same
+script can live in repos that aren't synced to voitta-rag.
+
+**4. Verify.**
+
+Make a commit. You should see a line like:
+
+```
+[voitta-rag] {"folder_path":"my-repo","status":"syncing","message":"Sync started"}
+```
+
+Set `VOITTA_HOOK_QUIET=1` to suppress that line if your commit output
+must stay clean.
+
+**5. Watch the sync progress.**
+
+Sync runs in the background on the voitta-rag side; the hook returns
+immediately. Tail the server's app log to confirm:
+
+```
+docker exec <voitta-rag-container> tail -f logs/app.log | grep -E "sync|llm-tldr"
+```
+
+**Notes**
+
+- The hook exits 0 unconditionally on any error so a voitta-rag outage
+  never blocks a commit.
+- The hook never reads your commit content; it just pings the API.
+- The endpoint is HTTP only — terminate TLS at a reverse proxy if your
+  voitta-rag listens on the public network.
 
 

--- a/scripts/git-hooks/post-commit
+++ b/scripts/git-hooks/post-commit
@@ -1,0 +1,54 @@
+#!/usr/bin/env bash
+#
+# voitta-rag post-commit hook: pings the local voitta-rag instance to
+# re-sync (and re-run llm-tldr analysis) for a configured folder after
+# every commit. See "Advanced > Git post-commit hook" in the voitta-rag
+# README for installation instructions.
+#
+# Required environment variables:
+#   VOITTA_RAG_URL          e.g. http://localhost:58000
+#   VOITTA_RAG_FOLDER       voitta-rag folder_path the Git source is configured under
+#                           (e.g. "my-repo" or "vrag-test-4")
+#   VOITTA_HOOK_SECRET      same value as VOITTA_HOOK_SECRET on the voitta-rag server
+#
+# Optional:
+#   VOITTA_HOOK_TIMEOUT     curl --max-time, default 5 (seconds)
+#   VOITTA_HOOK_QUIET       if set, suppress stdout (commit output stays clean)
+#
+# The hook returns 0 unconditionally so a sync failure never blocks a
+# commit. Look at voitta-rag's logs/app.log for sync errors.
+
+set -u
+
+# Bail out cleanly if the hook isn't configured. Lets the same hook
+# file live in repos that aren't synced to voitta-rag.
+if [[ -z "${VOITTA_RAG_URL:-}" \
+   || -z "${VOITTA_RAG_FOLDER:-}" \
+   || -z "${VOITTA_HOOK_SECRET:-}" ]]; then
+    exit 0
+fi
+
+VOITTA_HOOK_TIMEOUT="${VOITTA_HOOK_TIMEOUT:-5}"
+
+URL="${VOITTA_RAG_URL%/}/api/sync/_hook/sync/${VOITTA_RAG_FOLDER}"
+
+# Fire and forget. Sync runs in the background on the voitta-rag side,
+# so the curl returns as soon as the trigger is accepted.
+if [[ -n "${VOITTA_HOOK_QUIET:-}" ]]; then
+    curl -fsS \
+        -X POST \
+        --max-time "$VOITTA_HOOK_TIMEOUT" \
+        -H "X-Voitta-Hook-Secret: ${VOITTA_HOOK_SECRET}" \
+        "$URL" >/dev/null 2>&1 || true
+else
+    response=$(curl -fsS \
+        -X POST \
+        --max-time "$VOITTA_HOOK_TIMEOUT" \
+        -H "X-Voitta-Hook-Secret: ${VOITTA_HOOK_SECRET}" \
+        "$URL" 2>&1) || true
+    if [[ -n "$response" ]]; then
+        echo "[voitta-rag] $response"
+    fi
+fi
+
+exit 0

--- a/src/voitta/api/routes/sync.py
+++ b/src/voitta/api/routes/sync.py
@@ -3,7 +3,10 @@
 import base64
 import logging
 
-from fastapi import APIRouter, BackgroundTasks, HTTPException, Query, status
+import os
+import secrets as _secrets
+
+from fastapi import APIRouter, BackgroundTasks, Header, HTTPException, Query, status
 from fastapi.responses import HTMLResponse, RedirectResponse
 from pydantic import BaseModel
 from sqlalchemy import select
@@ -773,6 +776,62 @@ async def trigger_sync(
 
     return SyncTriggerResponse(
         folder_path=path, status="syncing", message="Sync started"
+    )
+
+
+@router.post("/_hook/sync/{path:path}", response_model=SyncTriggerResponse)
+async def hook_trigger_sync(
+    path: str,
+    db: DB,
+    background_tasks: BackgroundTasks,
+    x_voitta_hook_secret: str = Header(default=""),
+):
+    """Trigger a sync from an out-of-process hook (e.g. git post-commit).
+
+    Authenticated by the ``X-Voitta-Hook-Secret`` request header, which
+    is compared in constant time against the ``VOITTA_HOOK_SECRET``
+    environment variable. The route is intentionally NOT cookie-gated so
+    a shell script can call it from a developer's git post-commit hook
+    without needing a logged-in browser session. When the env var is
+    unset the route is disabled (returns 403) — opt-in by design.
+
+    Body and response shape match the regular ``/{path}/trigger``
+    endpoint.
+    """
+    expected = os.getenv("VOITTA_HOOK_SECRET", "")
+    if not expected:
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail="VOITTA_HOOK_SECRET is not set; hook endpoint disabled",
+        )
+    if not _secrets.compare_digest(expected, x_voitta_hook_secret):
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail="invalid hook secret",
+        )
+
+    result = await db.execute(
+        select(FolderSyncSource).where(FolderSyncSource.folder_path == path)
+    )
+    source = result.scalar_one_or_none()
+    if not source:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail="No sync source configured for this folder",
+        )
+
+    if source.sync_status == "syncing":
+        return SyncTriggerResponse(
+            folder_path=path, status="syncing", message="Sync already in progress"
+        )
+
+    source.sync_status = "syncing"
+    source.sync_error = None
+    await db.flush()
+    background_tasks.add_task(_run_sync, path)
+
+    return SyncTriggerResponse(
+        folder_path=path, status="syncing", message="Sync started",
     )
 
 


### PR DESCRIPTION
## Summary

Last bullet of issue #15: a Git post-commit hook that pokes voitta-rag to re-sync (and re-run llm-tldr analysis) on every local commit. Keeps the indexed snapshot — both raw code chunks AND Phase 1+ companion chunks — in lockstep with `HEAD` without waiting for the next scheduled sync.

### What ships

1. **New endpoint** `POST /api/sync/_hook/sync/{folder_path}`. Body and response shape identical to the existing cookie-authed `/api/sync/{path}/trigger`; the only difference is the auth scheme:

   - Authenticated by `X-Voitta-Hook-Secret` request header, compared in constant time against `VOITTA_HOOK_SECRET` env var.
   - Returns 403 when the env var is unset → **strictly opt-in**; existing deployments don't suddenly expose an unauth'd sync trigger.

2. **`scripts/git-hooks/post-commit`** — a portable bash hook. Reads `VOITTA_RAG_URL`, `VOITTA_RAG_FOLDER`, `VOITTA_HOOK_SECRET` from env, curls the endpoint, never blocks a commit (`exit 0` on every error). Optional `VOITTA_HOOK_QUIET=1` to silence stdout in already-noisy commit pipelines.

3. **README "Advanced > Git post-commit hook"** with end-to-end install: enable the env var, restart the container, copy the hook into the target repo's `.git/hooks/`, set the three env vars in shell rc.

### Why not cookie auth

Cookie auth is the only existing scheme. Piping a browser cookie into a git hook is awkward — it's tied to a specific session and breaks on logout. A shared-secret header is the minimum viable serverless-auth surface for this use case. A real per-user API token system can come later; that's a separate scope.

### Why not an MCP tool

Considered, dropped. `fastmcp` tools speak MCP over HTTP, not plain `curl` — a bash hook would have to craft MCP-protocol payloads. The shared-secret REST route is universal: curl, wget, and any HTTP client work without an MCP layer. If you want MCP, see the existing `search` tool — Phase 5 (blog post) is a more useful next step than a redundant MCP wrapper.

## Test plan

- [ ] Set `VOITTA_HOOK_SECRET=<long-random>` in `.env`; restart voitta-rag.
- [ ] Without the header: `curl -X POST .../api/sync/_hook/sync/some-folder` → 403.
- [ ] With wrong header value: → 403.
- [ ] With correct header for a non-existent folder: → 404.
- [ ] With correct header for a configured folder: → 200, response body `{"status": "syncing", ...}`, server-side `_run_sync` fires.
- [ ] Install the hook in a small repo synced to voitta-rag. `git commit --allow-empty -m "test"`. See `[voitta-rag] ...` line on stdout. `sync_status` flips to `syncing` then `synced` on the server.
- [ ] Unset `VOITTA_HOOK_SECRET` on the server, retry: → 403, "endpoint disabled".

Refs: #15
