### PR TITLE
Index llm-tldr static analysis as companion documents for Git repos (#15)

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,7 @@ Useful for teams and individuals who want to:
   - [Round-trip between machines](#round-trip-between-machines)
 - [Advanced](#advanced)
   - [SQLite journal mode on Docker bind-mounts](#sqlite-journal-mode-on-docker-bind-mounts)
+  - [Git post-commit hook](#git-post-commit-hook)
 
 ## Features
 
@@ -500,5 +501,95 @@ sqlite3 voitta.db "PRAGMA journal_mode = WAL;"
 
 See also the [SQLite docs on journal mode](https://www.sqlite.org/pragma.html#pragma_journal_mode)
 and [WAL mode caveats on networked filesystems](https://www.sqlite.org/wal.html#sometimes_queries_return_sqlite_busy_in_wal_mode).
+
+### Git post-commit hook
+
+> **For operators only.** Skip this if your Git sources reindex on a
+> schedule and you don't need fresh data after each commit.
+
+If you have a voitta-rag Git source pointed at a repository you actively
+work on, you can wire a post-commit hook in that repository so every
+local commit immediately triggers a sync (which also re-runs the
+optional `llm-tldr` static analysis from issue [#15](https://github.com/voitta-ai/voitta-rag/issues/15)).
+This keeps the indexed snapshot — both raw code chunks and structural
+analysis chunks — in lockstep with `HEAD` on your machine without
+waiting for the next scheduled sync.
+
+**1. Enable the hook endpoint on the voitta-rag server.**
+
+The hook calls `POST /api/sync/_hook/sync/{folder_path}` which is
+authenticated by a shared secret in the `X-Voitta-Hook-Secret` header,
+not by browser cookie. The route is disabled (returns 403) when the
+secret env var is unset, so this is strictly opt-in.
+
+In your voitta-rag `.env`:
+
+```
+VOITTA_HOOK_SECRET=<choose a long random string>
+```
+
+Restart the container so the new env var is picked up:
+
+```
+docker compose restart voitta-rag
+```
+
+**2. Install the hook in your repo.**
+
+Copy `scripts/git-hooks/post-commit` from this repo into your target
+repo's `.git/hooks/` directory and make it executable:
+
+```
+cp /path/to/voitta-rag/scripts/git-hooks/post-commit \
+   /path/to/my-repo/.git/hooks/post-commit
+chmod +x /path/to/my-repo/.git/hooks/post-commit
+```
+
+If you maintain shared hooks across multiple repos via `core.hooksPath`
+or a tool like [husky](https://typicode.github.io/husky/), drop the
+script there instead.
+
+**3. Tell the hook how to reach your voitta-rag.**
+
+The hook reads three environment variables. Set them in your shell rc
+file (`~/.bashrc`, `~/.zshrc`, etc.) so they're available whenever you
+commit:
+
+```
+export VOITTA_RAG_URL=http://localhost:58000
+export VOITTA_RAG_FOLDER=my-repo              # the voitta-rag folder_path
+export VOITTA_HOOK_SECRET=<same value as on the server>
+```
+
+The hook bails out silently when any of these is unset, so the same
+script can live in repos that aren't synced to voitta-rag.
+
+**4. Verify.**
+
+Make a commit. You should see a line like:
+
+```
+[voitta-rag] {"folder_path":"my-repo","status":"syncing","message":"Sync started"}
+```
+
+Set `VOITTA_HOOK_QUIET=1` to suppress that line if your commit output
+must stay clean.
+
+**5. Watch the sync progress.**
+
+Sync runs in the background on the voitta-rag side; the hook returns
+immediately. Tail the server's app log to confirm:
+
+```
+docker exec <voitta-rag-container> tail -f logs/app.log | grep -E "sync|llm-tldr"
+```
+
+**Notes**
+
+- The hook exits 0 unconditionally on any error so a voitta-rag outage
+  never blocks a commit.
+- The hook never reads your commit content; it just pings the API.
+- The endpoint is HTTP only — terminate TLS at a reverse proxy if your
+  voitta-rag listens on the public network.
 
 

--- a/README.md
+++ b/README.md
@@ -37,6 +37,8 @@ Useful for teams and individuals who want to:
   - [Customizing](#customizing)
   - [Exporting from a running instance](#exporting-from-a-running-instance)
   - [Round-trip between machines](#round-trip-between-machines)
+- [Advanced](#advanced)
+  - [SQLite journal mode on Docker bind-mounts](#sqlite-journal-mode-on-docker-bind-mounts)
 
 ## Features
 
@@ -435,4 +437,68 @@ python3 scripts/import_repos.py /tmp/repos.json
 ```
 
 If the target uses token auth, edit `/tmp/repos.json` on machine B to fill in `username` and `token` under each `hosts` entry before running the import. For SSH auth, make sure the target machine's SSH key is present on `~/.ssh` (mounted into the container) and authorized on GitHub.
+
+## Advanced
+
+### SQLite journal mode on Docker bind-mounts
+
+> **For operators only.** Skip this unless you hit the symptom below.
+
+voitta-rag stores its operational metadata in a SQLite database
+(`voitta.db`). By default SQLite picks rollback journaling (mode
+`delete`), which is the safe choice when the file lives on a Docker
+bind-mount from a macOS or Windows host. The application does **not**
+force a journal mode — it leaves whatever the file header specifies.
+
+**Symptom:** under sustained use on a bind-mounted setup (Docker
+Desktop, Rancher Desktop, OrbStack on macOS or Windows), some HTTP
+endpoints intermittently fail with:
+
+```
+sqlalchemy.exc.OperationalError: (sqlite3.OperationalError) disk I/O error
+```
+
+while `sqlite3 voitta.db "PRAGMA integrity_check;"` returns `ok` and
+the host can read the same query without issue. Restarting the
+container temporarily fixes it, then it comes back.
+
+**Root cause:** the database is using SQLite's WAL (write-ahead log)
+journal mode. WAL relies on a `-shm` shared-memory page that does not
+cross the host/VM file-sharing boundary cleanly. Stale `-shm`
+mappings — left over from a previous container session, laptop sleep,
+or a host-side process that touched the file — surface as EIO on the
+next query.
+
+**Fix:** force the database to use rollback journaling (mode `delete`)
+once. The setting is persisted in the SQLite file header and survives
+container restarts.
+
+```bash
+# 1. Stop the voitta-rag container so nothing has the DB open.
+docker compose stop voitta-rag
+
+# 2. Truncate any pending WAL and switch journal_mode on the file.
+sqlite3 $VOITTA_ROOT_PATH/voitta.db "PRAGMA wal_checkpoint(TRUNCATE);"
+sqlite3 $VOITTA_ROOT_PATH/voitta.db "PRAGMA journal_mode = DELETE;"
+
+# 3. Confirm the change stuck.
+sqlite3 $VOITTA_ROOT_PATH/voitta.db "PRAGMA journal_mode;"   # prints: delete
+
+# 4. Bring the container back up.
+docker compose start voitta-rag
+```
+
+**Trade-off:** rollback journaling serializes writes against reads, so
+on a single-writer / many-reader workload like voitta-rag the cost is
+modest. If your workload is write-heavy enough that you actually need
+WAL throughput and you are not on a bind-mount (e.g. you've moved the
+DB into a Docker named volume), you can force WAL the same way:
+
+```bash
+sqlite3 voitta.db "PRAGMA journal_mode = WAL;"
+```
+
+See also the [SQLite docs on journal mode](https://www.sqlite.org/pragma.html#pragma_journal_mode)
+and [WAL mode caveats on networked filesystems](https://www.sqlite.org/wal.html#sometimes_queries_return_sqlite_busy_in_wal_mode).
+
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -40,6 +40,8 @@ dependencies = [
     "google-auth>=2.23.0",
     # AWS
     "boto3>=1.28.0",
+    # Static analysis (optional companion indexing for Git sources, see issue #15)
+    "llm-tldr>=0.1.0",
 ]
 
 [project.optional-dependencies]

--- a/requirements.txt
+++ b/requirements.txt
@@ -30,3 +30,6 @@ boto3>=1.28.0
 
 # MCP server
 fastmcp>=0.4.0
+
+# Static analysis (optional companion indexing for Git sources, see issue #15)
+llm-tldr>=0.1.0

--- a/scripts/git-hooks/post-commit
+++ b/scripts/git-hooks/post-commit
@@ -1,0 +1,54 @@
+#!/usr/bin/env bash
+#
+# voitta-rag post-commit hook: pings the local voitta-rag instance to
+# re-sync (and re-run llm-tldr analysis) for a configured folder after
+# every commit. See "Advanced > Git post-commit hook" in the voitta-rag
+# README for installation instructions.
+#
+# Required environment variables:
+#   VOITTA_RAG_URL          e.g. http://localhost:58000
+#   VOITTA_RAG_FOLDER       voitta-rag folder_path the Git source is configured under
+#                           (e.g. "my-repo" or "vrag-test-4")
+#   VOITTA_HOOK_SECRET      same value as VOITTA_HOOK_SECRET on the voitta-rag server
+#
+# Optional:
+#   VOITTA_HOOK_TIMEOUT     curl --max-time, default 5 (seconds)
+#   VOITTA_HOOK_QUIET       if set, suppress stdout (commit output stays clean)
+#
+# The hook returns 0 unconditionally so a sync failure never blocks a
+# commit. Look at voitta-rag's logs/app.log for sync errors.
+
+set -u
+
+# Bail out cleanly if the hook isn't configured. Lets the same hook
+# file live in repos that aren't synced to voitta-rag.
+if [[ -z "${VOITTA_RAG_URL:-}" \
+   || -z "${VOITTA_RAG_FOLDER:-}" \
+   || -z "${VOITTA_HOOK_SECRET:-}" ]]; then
+    exit 0
+fi
+
+VOITTA_HOOK_TIMEOUT="${VOITTA_HOOK_TIMEOUT:-5}"
+
+URL="${VOITTA_RAG_URL%/}/api/sync/_hook/sync/${VOITTA_RAG_FOLDER}"
+
+# Fire and forget. Sync runs in the background on the voitta-rag side,
+# so the curl returns as soon as the trigger is accepted.
+if [[ -n "${VOITTA_HOOK_QUIET:-}" ]]; then
+    curl -fsS \
+        -X POST \
+        --max-time "$VOITTA_HOOK_TIMEOUT" \
+        -H "X-Voitta-Hook-Secret: ${VOITTA_HOOK_SECRET}" \
+        "$URL" >/dev/null 2>&1 || true
+else
+    response=$(curl -fsS \
+        -X POST \
+        --max-time "$VOITTA_HOOK_TIMEOUT" \
+        -H "X-Voitta-Hook-Secret: ${VOITTA_HOOK_SECRET}" \
+        "$URL" 2>&1) || true
+    if [[ -n "$response" ]]; then
+        echo "[voitta-rag] $response"
+    fi
+fi
+
+exit 0

--- a/src/voitta/api/routes/sync.py
+++ b/src/voitta/api/routes/sync.py
@@ -3,7 +3,10 @@
 import base64
 import logging
 
-from fastapi import APIRouter, BackgroundTasks, HTTPException, Query, status
+import os
+import secrets as _secrets
+
+from fastapi import APIRouter, BackgroundTasks, Header, HTTPException, Query, status
 from fastapi.responses import HTMLResponse, RedirectResponse
 from pydantic import BaseModel
 from sqlalchemy import select
@@ -773,6 +776,62 @@ async def trigger_sync(
 
     return SyncTriggerResponse(
         folder_path=path, status="syncing", message="Sync started"
+    )
+
+
+@router.post("/_hook/sync/{path:path}", response_model=SyncTriggerResponse)
+async def hook_trigger_sync(
+    path: str,
+    db: DB,
+    background_tasks: BackgroundTasks,
+    x_voitta_hook_secret: str = Header(default=""),
+):
+    """Trigger a sync from an out-of-process hook (e.g. git post-commit).
+
+    Authenticated by the ``X-Voitta-Hook-Secret`` request header, which
+    is compared in constant time against the ``VOITTA_HOOK_SECRET``
+    environment variable. The route is intentionally NOT cookie-gated so
+    a shell script can call it from a developer's git post-commit hook
+    without needing a logged-in browser session. When the env var is
+    unset the route is disabled (returns 403) — opt-in by design.
+
+    Body and response shape match the regular ``/{path}/trigger``
+    endpoint.
+    """
+    expected = os.getenv("VOITTA_HOOK_SECRET", "")
+    if not expected:
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail="VOITTA_HOOK_SECRET is not set; hook endpoint disabled",
+        )
+    if not _secrets.compare_digest(expected, x_voitta_hook_secret):
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail="invalid hook secret",
+        )
+
+    result = await db.execute(
+        select(FolderSyncSource).where(FolderSyncSource.folder_path == path)
+    )
+    source = result.scalar_one_or_none()
+    if not source:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail="No sync source configured for this folder",
+        )
+
+    if source.sync_status == "syncing":
+        return SyncTriggerResponse(
+            folder_path=path, status="syncing", message="Sync already in progress"
+        )
+
+    source.sync_status = "syncing"
+    source.sync_error = None
+    await db.flush()
+    background_tasks.add_task(_run_sync, path)
+
+    return SyncTriggerResponse(
+        folder_path=path, status="syncing", message="Sync started",
     )
 
 

--- a/src/voitta/api/routes/sync.py
+++ b/src/voitta/api/routes/sync.py
@@ -50,6 +50,7 @@ class GitHubConfig(BaseModel):
     username: str = ""  # For token auth (e.g. GitHub username or x-access-token)
     token: str = ""  # Personal access token (PAT)
     all_branches: bool = False
+    llm_tldr: bool = False  # Run llm-tldr static analysis on synced repo
 
 
 class AzureDevOpsConfig(BaseModel):
@@ -187,6 +188,7 @@ def _to_response(source: FolderSyncSource) -> SyncSourceResponse:
             username=source.gh_username or "",
             token=source.gh_pat or "",
             all_branches=source.gh_all_branches or False,
+            llm_tldr=source.gh_llm_tldr or False,
         )
     elif source.source_type == "azure_devops":
         ado = AzureDevOpsConfig(
@@ -837,6 +839,7 @@ async def upsert_sync_source(
         "gd_service_account_json", "gd_folder_id", "gd_client_id", "gd_client_secret",
         "gh_token", "gh_repo", "gh_branch", "gh_path",
         "gh_auth_method", "gh_username", "gh_pat", "gh_all_branches",
+        "gh_llm_tldr",
         "ado_tenant_id", "ado_client_id", "ado_client_secret",
         "ado_organization", "ado_project", "ado_url",
         "jira_url", "jira_project", "jira_token", "jira_auth_method", "jira_email",
@@ -876,6 +879,7 @@ async def upsert_sync_source(
         source.gh_username = request.github.username
         source.gh_pat = request.github.token
         source.gh_all_branches = request.github.all_branches
+        source.gh_llm_tldr = request.github.llm_tldr
     elif request.source_type == "azure_devops" and request.azure_devops:
         from ...services.sync.azure_devops import _parse_ado_url
         source.ado_tenant_id = request.azure_devops.tenant_id

--- a/src/voitta/api/routes/sync.py
+++ b/src/voitta/api/routes/sync.py
@@ -995,10 +995,20 @@ async def delete_sync_source(path: str, user: CurrentUser, db: DB):
 
 
 async def _run_sync(folder_path: str):
-    """Run sync in background."""
+    """Run sync in background.
+
+    The async DB session is held only across short read / write windows.
+    The long-running ``connector.sync()`` call runs with NO async session
+    open, so the shared file-lock from a pending read transaction does
+    not block sync-worker sub-tasks (e.g. the llm-tldr indexer running in
+    a thread via a sync ``Session``) under journal_mode=DELETE. Under WAL
+    a long-lived read txn was harmless; under DELETE it serialises every
+    other writer.
+    """
     from ...services.filesystem import FilesystemService
     from ...services.watcher import file_watcher
 
+    # Step 1: load source, detach, close session.
     async with get_db_context() as db:
         result = await db.execute(
             select(FolderSyncSource).where(FolderSyncSource.folder_path == folder_path)
@@ -1006,73 +1016,87 @@ async def _run_sync(folder_path: str):
         source = result.scalar_one_or_none()
         if not source:
             return
+        db.expunge(source)
 
-        # Suppress file watcher events for this folder during sync
-        file_watcher.suppress_path(folder_path)
-        try:
-            connector = get_connector(source.source_type)
-            from ...services.filesystem import get_filesystem_service as _get_fs
-            fs = _get_fs()
-            await connector.sync(source, fs)
+    file_watcher.suppress_path(folder_path)
+    final_status = "synced"
+    final_error: str | None = None
+    last_synced_at = None
 
-            # Post-sync: fetch Teams meeting transcripts for SharePoint sources
-            if source.source_type == "sharepoint":
-                try:
-                    from ...services.sync.teams_transcripts import fetch_transcripts_for_folder
-                    token = await connector._get_access_token(source)
-                    count = await fetch_transcripts_for_folder(source, fs, token)
-                    if count:
-                        logger.info("Fetched %d transcript(s) for %s", count, folder_path)
-                except Exception as e:
-                    logger.warning("Transcript fetch failed for %s: %s", folder_path, e)
+    try:
+        connector = get_connector(source.source_type)
+        from ...services.filesystem import get_filesystem_service as _get_fs
+        fs = _get_fs()
+        await connector.sync(source, fs)
 
-            # Post-sync: reconcile index with new disk state
+        # Post-sync: fetch Teams meeting transcripts for SharePoint sources
+        if source.source_type == "sharepoint":
             try:
-                from ...services.indexing import get_indexing_service
-                from sqlalchemy.orm import Session as SyncSession
-
-                indexing_service = get_indexing_service()
-                with SyncSession(get_sync_engine()) as sync_db:
-                    # Find all indexed/pending subfolders under this folder
-                    result = sync_db.execute(
-                        select(FolderIndexStatus).where(
-                            FolderIndexStatus.folder_path.startswith(folder_path),
-                            FolderIndexStatus.status.in_(["indexed", "pending"]),
-                        )
-                    )
-                    for idx_status in result.scalars().all():
-                        added, removed, _ = indexing_service.sync_folder(
-                            idx_status.folder_path, sync_db
-                        )
-                        if removed:
-                            logger.info(
-                                "Post-sync cleanup [%s]: removed %d stale files",
-                                idx_status.folder_path,
-                                removed,
-                            )
-                    sync_db.commit()
+                from ...services.sync.teams_transcripts import fetch_transcripts_for_folder
+                token = await connector._get_access_token(source)
+                count = await fetch_transcripts_for_folder(source, fs, token)
+                if count:
+                    logger.info("Fetched %d transcript(s) for %s", count, folder_path)
             except Exception as e:
-                logger.warning(
-                    "Post-sync index reconciliation failed for %s: %s",
-                    folder_path,
-                    e,
+                logger.warning("Transcript fetch failed for %s: %s", folder_path, e)
+
+        # Post-sync: reconcile index with new disk state. Uses its own
+        # short sync Session; no async session is open here.
+        try:
+            from ...services.indexing import get_indexing_service
+            from sqlalchemy.orm import Session as SyncSession
+
+            indexing_service = get_indexing_service()
+            with SyncSession(get_sync_engine()) as sync_db:
+                result = sync_db.execute(
+                    select(FolderIndexStatus).where(
+                        FolderIndexStatus.folder_path.startswith(folder_path),
+                        FolderIndexStatus.status.in_(["indexed", "pending"]),
+                    )
                 )
-
-            source.sync_status = "synced"
-            source.sync_error = None
-            source.last_synced_at = utc_now()
+                for idx_status in result.scalars().all():
+                    added, removed, _ = indexing_service.sync_folder(
+                        idx_status.folder_path, sync_db
+                    )
+                    if removed:
+                        logger.info(
+                            "Post-sync cleanup [%s]: removed %d stale files",
+                            idx_status.folder_path,
+                            removed,
+                        )
+                sync_db.commit()
         except Exception as e:
-            logger.exception("Sync failed for %s", folder_path)
-            source.sync_status = "error"
-            source.sync_error = str(e)
-        finally:
-            file_watcher.unsuppress_path(folder_path)
+            logger.warning(
+                "Post-sync index reconciliation failed for %s: %s",
+                folder_path,
+                e,
+            )
 
-        # Broadcast sync status change via WebSocket
-        await file_watcher.broadcast({
-            "type": "sync_status",
-            "path": folder_path,
-            "sync_status": source.sync_status,
-            "sync_error": source.sync_error,
-            "last_synced_at": source.last_synced_at.isoformat() if source.last_synced_at else None,
-        })
+        last_synced_at = utc_now()
+    except Exception as e:
+        logger.exception("Sync failed for %s", folder_path)
+        final_status = "error"
+        final_error = str(e)
+    finally:
+        file_watcher.unsuppress_path(folder_path)
+
+    # Step 2: write final status in a fresh short session.
+    async with get_db_context() as db:
+        result = await db.execute(
+            select(FolderSyncSource).where(FolderSyncSource.folder_path == folder_path)
+        )
+        persisted = result.scalar_one_or_none()
+        if persisted is not None:
+            persisted.sync_status = final_status
+            persisted.sync_error = final_error
+            if final_status == "synced":
+                persisted.last_synced_at = last_synced_at
+            await db.commit()
+
+    await file_watcher.broadcast({
+        "type": "sync_status",
+        "path": folder_path,
+        "sync_status": final_status,
+        "sync_error": final_error,
+        "last_synced_at": last_synced_at.isoformat() if last_synced_at else None,
+    })

--- a/src/voitta/db/database.py
+++ b/src/voitta/db/database.py
@@ -18,9 +18,18 @@ from .models import Base, FolderSyncSource, Project, User
 
 
 def _set_sqlite_pragmas(dbapi_conn, connection_record):
-    """Set SQLite pragmas on every new connection."""
+    """Set SQLite pragmas on every new connection.
+
+    journal_mode is intentionally NOT forced. It is a per-file setting
+    persisted in the SQLite header; pinning it on every connect blocks
+    operators from picking a non-WAL mode (e.g. DELETE) when the database
+    file lives on a Docker bind-mount, where WAL's shared-memory page
+    cannot cross the host/VM file-sharing boundary cleanly and produces
+    intermittent ``disk I/O error`` (SQLITE_IOERR_*) failures. Operators
+    pick a mode once with
+    ``sqlite3 voitta.db 'PRAGMA journal_mode = DELETE;'`` and it sticks.
+    """
     cursor = dbapi_conn.cursor()
-    cursor.execute("PRAGMA journal_mode=WAL")
     cursor.execute("PRAGMA busy_timeout=30000")
     cursor.close()
 
@@ -206,9 +215,19 @@ def _discover_docker_folders(engine: Engine) -> None:
                     logger.info("Removing stale Docker filesystem entry (has child sources): %s", source.folder_path)
                     session.delete(source)
 
-        # Mark remaining root-level entries as Docker-managed
+        # Clear is_docker_managed on non-filesystem sources. Only filesystem
+        # sources can correspond to Docker volume mounts; remote sync sources
+        # (github, sharepoint, jira, etc.) happen to live under root_path
+        # because that's where their synced files land, but they are not
+        # Docker-managed and must remain user-deletable.
         for source in all_sources:
-            if source.folder_path in root_folder_names:
+            if source.source_type != "filesystem" and source.is_docker_managed:
+                source.is_docker_managed = False
+
+        # Mark remaining filesystem root-level entries as Docker-managed.
+        for source in all_sources:
+            if (source.source_type == "filesystem"
+                    and source.folder_path in root_folder_names):
                 source.is_docker_managed = True
 
         session.commit()

--- a/src/voitta/db/models.py
+++ b/src/voitta/db/models.py
@@ -168,6 +168,7 @@ class FolderSyncSource(Base):
     gh_username: Mapped[str | None] = mapped_column(String(255), nullable=True)
     gh_pat: Mapped[str | None] = mapped_column(String(500), nullable=True)
     gh_all_branches: Mapped[bool | None] = mapped_column(Boolean, nullable=True, default=False)
+    gh_llm_tldr: Mapped[bool | None] = mapped_column(Boolean, nullable=True, default=False)
 
     # Azure DevOps credentials
     ado_tenant_id: Mapped[str | None] = mapped_column(String(255), nullable=True)
@@ -238,6 +239,22 @@ class IndexedFile(Base):
     chunk_count: Mapped[int] = mapped_column(Integer, default=0)
     source_created_at: Mapped[int | None] = mapped_column(Integer, nullable=True)
     source_modified_at: Mapped[int | None] = mapped_column(Integer, nullable=True)
+    indexed_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), default=utc_now)
+    updated_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), default=utc_now, onupdate=utc_now
+    )
+
+
+class LlmTldrIndexedFile(Base):
+    """Track llm-tldr companion analysis chunks per source file."""
+
+    __tablename__ = "llm_tldr_indexed_files"
+
+    id: Mapped[int] = mapped_column(Integer, primary_key=True)
+    folder_path: Mapped[str] = mapped_column(String(1000), nullable=False, index=True)
+    related_file: Mapped[str] = mapped_column(String(1000), nullable=False, index=True)
+    content_hash: Mapped[str] = mapped_column(String(64), nullable=False)
+    chunk_count: Mapped[int] = mapped_column(Integer, default=0)
     indexed_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), default=utc_now)
     updated_at: Mapped[datetime] = mapped_column(
         DateTime(timezone=True), default=utc_now, onupdate=utc_now

--- a/src/voitta/services/llm_tldr_indexer.py
+++ b/src/voitta/services/llm_tldr_indexer.py
@@ -5,16 +5,19 @@ structural summaries as companion chunks in Qdrant alongside the raw code
 chunks. Each chunk is tagged with ``source_type="llm-tldr-analysis"`` and
 ``related_file`` pointing back to the originating source file.
 
-Phase 1 (PoC): delete-and-replace per sync. Incremental reindexing arrives
-in phase 2 of issue #15.
+Phase 2: per-file incremental reindex. Source files are hashed; only files
+whose hash changed (or are newly added or removed) trigger an extract /
+chunk / store cycle. Set ``force=True`` to wipe and re-extract everything
+(useful after an llm-tldr library bump).
 """
 
+import hashlib
 import json
 import logging
 from datetime import datetime, timezone
 from pathlib import Path
 
-from sqlalchemy import delete
+from sqlalchemy import delete, select
 from sqlalchemy.orm import Session
 
 from ..db.models import LlmTldrIndexedFile
@@ -61,21 +64,30 @@ class LlmTldrIndexer:
         folder_path: str,
         index_folder: str,
         db: Session,
+        force: bool = False,
     ) -> dict:
-        """Run llm-tldr analysis over ``repo_dir`` and index companion chunks.
+        """Incrementally re-index llm-tldr companion chunks for ``repo_dir``.
+
+        Compares current source-file SHA-256 hashes against the
+        ``LlmTldrIndexedFile`` rows previously recorded for ``folder_path``
+        and only re-extracts the analysis for files that are new, changed,
+        or removed.
 
         Args:
             repo_dir: Local directory containing the cloned source files.
             folder_path: Voitta-RAG folder_path the chunks belong to (e.g.
-                "myrepo/branches/main"). All companion chunks for this folder
-                are wiped and replaced.
+                "myrepo/branches/main"). Companion chunks for this folder
+                are scoped by this value.
             index_folder: Folder at which indexing was triggered (the
                 top-level Git source folder, used for filtered searches).
             db: Active SQLAlchemy session.
+            force: If True, wipes every companion chunk for the folder and
+                re-extracts every file. Use after an llm-tldr library bump
+                or when the rendering format changes.
 
         Returns:
-            Stats dict with files_analyzed, files_skipped, chunks_stored,
-            errors counts.
+            Stats dict with files_new, files_updated, files_removed,
+            files_unchanged, files_skipped, chunks_stored, errors counts.
         """
         try:
             from tldr.api import extract_file  # type: ignore
@@ -84,37 +96,72 @@ class LlmTldrIndexer:
                 "llm-tldr is not installed; skipping companion indexing: %s", e,
             )
             return {
-                "files_analyzed": 0, "files_skipped": 0,
+                "files_new": 0, "files_updated": 0, "files_removed": 0,
+                "files_unchanged": 0, "files_skipped": 0,
                 "chunks_stored": 0, "errors": 1,
             }
 
         stats = {
-            "files_analyzed": 0, "files_skipped": 0,
+            "files_new": 0, "files_updated": 0, "files_removed": 0,
+            "files_unchanged": 0, "files_skipped": 0,
             "chunks_stored": 0, "errors": 0,
         }
 
-        deleted = self.vector_store.delete_by_folder_and_source_type(
-            folder_path, SOURCE_TYPE,
-        )
-        logger.info(
-            "llm-tldr: wiped %d stale companion chunks for %s",
-            deleted, folder_path,
-        )
-        db.execute(
-            delete(LlmTldrIndexedFile).where(
+        if force:
+            wiped = self.vector_store.delete_by_folder_and_source_type(
+                folder_path, SOURCE_TYPE,
+            )
+            logger.info(
+                "llm-tldr: force=True wiped %d chunks for %s", wiped, folder_path,
+            )
+            db.execute(
+                delete(LlmTldrIndexedFile).where(
+                    LlmTldrIndexedFile.folder_path == folder_path
+                )
+            )
+            db.flush()
+
+        # Snapshot known state from the DB.
+        existing_rows = db.execute(
+            select(LlmTldrIndexedFile).where(
                 LlmTldrIndexedFile.folder_path == folder_path
             )
-        )
-        db.flush()
+        ).scalars().all()
+        existing_by_rel: dict[str, LlmTldrIndexedFile] = {
+            row.related_file: row for row in existing_rows
+        }
 
+        # Snapshot current source-file hashes.
         files = _collect_source_files(repo_dir)
-        logger.info(
-            "llm-tldr: analyzing %d source files under %s",
-            len(files), repo_dir,
-        )
-
+        current_hashes: dict[str, str] = {}
         for src in files:
             rel = str(src.relative_to(repo_dir))
+            try:
+                current_hashes[rel] = _hash_file(src)
+            except OSError as e:
+                logger.debug("llm-tldr: unreadable %s: %s", rel, e)
+                stats["files_skipped"] += 1
+
+        logger.info(
+            "llm-tldr: scanning %s — %d source files on disk, %d previously indexed",
+            folder_path, len(current_hashes), len(existing_by_rel),
+        )
+
+        # Removed files: in DB, not on disk → delete their chunks + rows.
+        removed = set(existing_by_rel) - set(current_hashes)
+        for rel in removed:
+            self.vector_store.delete_by_folder_and_related_file(folder_path, rel)
+            db.delete(existing_by_rel[rel])
+            stats["files_removed"] += 1
+
+        # New / changed files: extract, store, upsert row.
+        for rel, source_hash in current_hashes.items():
+            existing_row = existing_by_rel.get(rel)
+            if existing_row is not None and existing_row.content_hash == source_hash:
+                stats["files_unchanged"] += 1
+                continue
+
+            src = repo_dir / rel
             try:
                 info = extract_file(str(src), base_path=str(repo_dir))
             except Exception as e:
@@ -126,6 +173,12 @@ class LlmTldrIndexer:
             if not text.strip():
                 stats["files_skipped"] += 1
                 continue
+
+            # Replace any prior chunks for this file before reinserting.
+            if existing_row is not None:
+                self.vector_store.delete_by_folder_and_related_file(
+                    folder_path, rel,
+                )
 
             try:
                 chunks_stored = self._store_chunks(
@@ -141,16 +194,21 @@ class LlmTldrIndexer:
                 stats["errors"] += 1
                 continue
 
-            content_hash = _hash_text(text)
-            db.add(
-                LlmTldrIndexedFile(
-                    folder_path=folder_path,
-                    related_file=rel,
-                    content_hash=content_hash,
-                    chunk_count=chunks_stored,
+            if existing_row is None:
+                db.add(
+                    LlmTldrIndexedFile(
+                        folder_path=folder_path,
+                        related_file=rel,
+                        content_hash=source_hash,
+                        chunk_count=chunks_stored,
+                    )
                 )
-            )
-            stats["files_analyzed"] += 1
+                stats["files_new"] += 1
+            else:
+                existing_row.content_hash = source_hash
+                existing_row.chunk_count = chunks_stored
+                existing_row.updated_at = datetime.now(timezone.utc)
+                stats["files_updated"] += 1
             stats["chunks_stored"] += chunks_stored
 
         db.commit()
@@ -305,9 +363,13 @@ def _render_class(cls) -> str:
     return "\n".join(parts)
 
 
-def _hash_text(text: str) -> str:
-    import hashlib
-    return hashlib.sha256(text.encode("utf-8")).hexdigest()
+def _hash_file(path: Path) -> str:
+    """SHA-256 hash of the file's raw bytes."""
+    sha = hashlib.sha256()
+    with open(path, "rb") as f:
+        for chunk in iter(lambda: f.read(8192), b""):
+            sha.update(chunk)
+    return sha.hexdigest()
 
 
 def get_llm_tldr_indexer() -> LlmTldrIndexer:

--- a/src/voitta/services/llm_tldr_indexer.py
+++ b/src/voitta/services/llm_tldr_indexer.py
@@ -12,7 +12,6 @@ chunk / store cycle. Set ``force=True`` to wipe and re-extract everything
 """
 
 import hashlib
-import json
 import logging
 from datetime import datetime, timezone
 from pathlib import Path
@@ -176,8 +175,8 @@ class LlmTldrIndexer:
                 stats["files_skipped"] += 1
                 continue
 
-            text = _render_extract(rel, info)
-            if not text.strip():
+            parts = _build_chunk_parts(rel, info)
+            if not parts:
                 stats["files_skipped"] += 1
                 continue
 
@@ -188,8 +187,8 @@ class LlmTldrIndexer:
                 )
 
             try:
-                chunks_stored = self._store_chunks(
-                    text=text,
+                chunks_stored = self._store_chunk_parts(
+                    parts=parts,
                     related_file=rel,
                     folder_path=folder_path,
                     index_folder=index_folder,
@@ -222,42 +221,58 @@ class LlmTldrIndexer:
         logger.info("llm-tldr: indexing complete for %s: %s", folder_path, stats)
         return stats
 
-    def _store_chunks(
+    def _store_chunk_parts(
         self,
-        text: str,
+        parts: list[tuple[str, dict]],
         related_file: str,
         folder_path: str,
         index_folder: str,
     ) -> int:
-        chunks = self.chunker.chunk_text(text)
-        if not chunks:
+        """Embed and store pre-built (text, payload-overrides) tuples.
+
+        Each part becomes one Qdrant point. The text body goes through
+        the dense+sparse embedder; ``payload_overrides`` contains the
+        Phase 3 call-graph fields specific to that chunk (function name,
+        callers/callees, etc.).
+        """
+        if not parts:
             return 0
 
-        texts = [c.text for c in chunks]
+        texts = [text for text, _ in parts]
         embeddings = self.embedder.embed_texts(texts)
         sparse_vectors = self.sparse_embedder.embed_texts(texts)
 
         indexed_at = datetime.now(timezone.utc).isoformat()
         synthetic_path = f"llm-tldr://{folder_path}/{related_file}"
         chunk_data = []
-        for chunk, embedding in zip(chunks, embeddings):
+        for idx, ((text, payload_overrides), embedding) in enumerate(
+            zip(parts, embeddings)
+        ):
             metadata = ChunkMetadata(
                 file_path=synthetic_path,
                 folder_path=folder_path,
                 index_folder=index_folder,
                 file_name=Path(related_file).name + ".tldr.md",
-                chunk_index=chunk.index,
-                total_chunks=len(chunks),
-                start_char=chunk.start_char,
-                end_char=chunk.end_char,
+                chunk_index=idx,
+                total_chunks=len(parts),
+                start_char=0,
+                end_char=len(text),
                 indexed_at=indexed_at,
                 source_type=SOURCE_TYPE,
                 related_file=related_file,
+                tldr_chunk_kind=payload_overrides.get("tldr_chunk_kind"),
+                tldr_function_name=payload_overrides.get("tldr_function_name"),
+                tldr_class_name=payload_overrides.get("tldr_class_name"),
+                tldr_callees=payload_overrides.get("tldr_callees"),
+                tldr_callers=payload_overrides.get("tldr_callers"),
+                tldr_caller_count=payload_overrides.get("tldr_caller_count"),
+                tldr_callee_count=payload_overrides.get("tldr_callee_count"),
+                tldr_imports=payload_overrides.get("tldr_imports"),
             )
-            chunk_data.append((chunk.text, embedding, metadata))
+            chunk_data.append((text, embedding, metadata))
 
         self.vector_store.store_chunks(chunk_data, sparse_vectors=sparse_vectors)
-        return len(chunks)
+        return len(chunk_data)
 
 
 def _collect_source_files(repo_dir: Path) -> list[Path]:
@@ -278,101 +293,152 @@ def _collect_source_files(repo_dir: Path) -> list[Path]:
     return files
 
 
-def _render_extract(rel_path: str, info: dict) -> str:
-    """Render an llm-tldr extract_file dict as markdown text for chunking."""
-    lines: list[str] = []
-    lines.append(f"# llm-tldr analysis: {rel_path}")
+# Bumped whenever the analysis chunk format changes. Mixed into
+# _hash_file so existing rows whose content_hash was computed under a
+# previous format will mismatch and trigger a re-extract on the next
+# sync. v1: file-level rendered markdown (Phase 1+2). v3: per-function
+# chunks + call-graph payload (Phase 3).
+ANALYSIS_FORMAT_VERSION = "v3"
+
+
+def _build_chunk_parts(rel_path: str, info: dict) -> list[tuple[str, dict]]:
+    """Build (text, payload-overrides) tuples for one source file.
+
+    Emits one file_overview chunk plus one function chunk per top-level
+    function and per class method. Each function chunk carries the
+    structured call-graph payload (callers, callees, counts, imports)
+    needed for Phase 3 filtered searches.
+    """
+    parts: list[tuple[str, dict]] = []
+
+    # File overview
+    imports_list = _normalize_imports(info.get("imports") or [])
     lang = info.get("language") or "unknown"
-    lines.append(f"Language: {lang}")
+    overview_lines = [f"# llm-tldr file overview: {rel_path}"]
+    overview_lines.append(f"Language: {lang}")
     docstring = info.get("docstring")
     if docstring:
-        lines.append("")
-        lines.append("## Module docstring")
-        lines.append(docstring.strip())
-
-    imports = info.get("imports") or []
-    if imports:
-        lines.append("")
-        lines.append("## Imports")
-        for imp in imports:
-            lines.append(f"- {_render_import(imp)}")
-
-    functions = info.get("functions") or []
-    if functions:
-        lines.append("")
-        lines.append("## Functions")
-        for fn in functions:
-            lines.append(_render_function(fn))
-
-    classes = info.get("classes") or []
-    if classes:
-        lines.append("")
-        lines.append("## Classes")
-        for cls in classes:
-            lines.append(_render_class(cls))
+        overview_lines.append("")
+        overview_lines.append(docstring.strip())
+    if imports_list:
+        overview_lines.append("")
+        overview_lines.append("Imports: " + ", ".join(imports_list))
+    class_names = [
+        c.get("name") for c in (info.get("classes") or [])
+        if isinstance(c, dict) and c.get("name")
+    ]
+    if class_names:
+        overview_lines.append("Classes: " + ", ".join(class_names))
+    func_names = [
+        f.get("name") for f in (info.get("functions") or [])
+        if isinstance(f, dict) and f.get("name")
+    ]
+    if func_names:
+        overview_lines.append("Top-level functions: " + ", ".join(func_names))
+    parts.append((
+        "\n".join(overview_lines),
+        {
+            "tldr_chunk_kind": "file_overview",
+            "tldr_imports": imports_list or None,
+        },
+    ))
 
     call_graph = info.get("call_graph") or {}
-    if call_graph:
-        lines.append("")
-        lines.append("## Call graph")
-        lines.append("```json")
-        lines.append(json.dumps(call_graph, indent=2, default=str))
-        lines.append("```")
+    calls_map = call_graph.get("calls") or {}
+    called_by_map = call_graph.get("called_by") or {}
 
-    return "\n".join(lines)
+    # Top-level functions
+    for fn in info.get("functions") or []:
+        part = _build_function_part(
+            fn, class_name=None, rel_path=rel_path,
+            imports_list=imports_list,
+            calls_map=calls_map, called_by_map=called_by_map,
+        )
+        if part is not None:
+            parts.append(part)
+
+    # Class methods
+    for cls in info.get("classes") or []:
+        if not isinstance(cls, dict):
+            continue
+        cls_name = cls.get("name") or "(anonymous)"
+        for method in cls.get("methods") or []:
+            part = _build_function_part(
+                method, class_name=cls_name, rel_path=rel_path,
+                imports_list=imports_list,
+                calls_map=calls_map, called_by_map=called_by_map,
+            )
+            if part is not None:
+                parts.append(part)
+
+    return parts
 
 
-def _render_import(imp) -> str:
-    if isinstance(imp, dict):
-        module = imp.get("module") or imp.get("name") or ""
-        names = imp.get("names") or []
-        if names:
-            return f"{module} ({', '.join(map(str, names))})"
-        return str(module)
-    return str(imp)
-
-
-def _render_function(fn) -> str:
+def _build_function_part(
+    fn,
+    class_name: str | None,
+    rel_path: str,
+    imports_list: list[str],
+    calls_map: dict,
+    called_by_map: dict,
+) -> tuple[str, dict] | None:
     if not isinstance(fn, dict):
-        return f"- {fn}"
-    parts: list[str] = []
-    sig = fn.get("signature") or fn.get("name") or ""
-    parts.append(f"### {sig}")
-    if fn.get("docstring"):
-        parts.append(fn["docstring"].strip())
-    calls = fn.get("calls") or []
-    if calls:
-        parts.append(f"Calls: {', '.join(map(str, calls))}")
-    called_by = fn.get("called_by") or []
-    if called_by:
-        parts.append(f"Called by: {', '.join(map(str, called_by))}")
-    complexity = fn.get("complexity")
-    if complexity is not None:
-        parts.append(f"Cyclomatic complexity: {complexity}")
-    return "\n".join(parts)
+        return None
+    name = fn.get("name") or ""
+    if not name:
+        return None
+    key = f"{class_name}.{name}" if class_name else name
+    callees = list(calls_map.get(key) or [])
+    callers = list(called_by_map.get(key) or [])
+    sig = fn.get("signature") or name
+    lines = [f"# llm-tldr function: {key} (in {rel_path})"]
+    lines.append(f"Signature: {sig}")
+    if fn.get("is_async"):
+        lines.append("Async: True")
+    docstring = fn.get("docstring")
+    if docstring:
+        lines.append("")
+        lines.append(docstring.strip())
+    if callees:
+        lines.append("")
+        lines.append(f"Calls: {', '.join(callees)}")
+    if callers:
+        lines.append(f"Called by: {', '.join(callers)}")
+    text = "\n".join(lines)
+    payload = {
+        "tldr_chunk_kind": "function",
+        "tldr_function_name": name,
+        "tldr_class_name": class_name,
+        "tldr_callees": callees or None,
+        "tldr_callers": callers or None,
+        "tldr_caller_count": len(callers),
+        "tldr_callee_count": len(callees),
+        "tldr_imports": imports_list or None,
+    }
+    return (text, payload)
 
 
-def _render_class(cls) -> str:
-    if not isinstance(cls, dict):
-        return f"- {cls}"
-    parts: list[str] = []
-    name = cls.get("name") or "(anonymous)"
-    bases = cls.get("bases") or cls.get("base_classes") or []
-    header = f"### class {name}"
-    if bases:
-        header += f"({', '.join(map(str, bases))})"
-    parts.append(header)
-    if cls.get("docstring"):
-        parts.append(cls["docstring"].strip())
-    methods = cls.get("methods") or []
-    for m in methods:
-        parts.append(_render_function(m))
-    return "\n".join(parts)
+def _normalize_imports(imports) -> list[str]:
+    """Reduce llm-tldr's import entries to a flat list of module names."""
+    out: list[str] = []
+    for imp in imports:
+        if isinstance(imp, dict):
+            mod = imp.get("module") or imp.get("name")
+            if mod:
+                out.append(str(mod))
+        elif imp:
+            out.append(str(imp))
+    return out
 
 
 def _hash_file(path: Path) -> str:
-    """SHA-256 hash of the file's raw bytes."""
+    """SHA-256 hash of the file's raw bytes, salted with the analysis
+    format version. A format-version bump invalidates all stored hashes
+    so the next sync re-extracts every file into the new format.
+    """
     sha = hashlib.sha256()
+    sha.update(ANALYSIS_FORMAT_VERSION.encode("ascii"))
+    sha.update(b"\0")
     with open(path, "rb") as f:
         for chunk in iter(lambda: f.read(8192), b""):
             sha.update(chunk)

--- a/src/voitta/services/llm_tldr_indexer.py
+++ b/src/voitta/services/llm_tldr_indexer.py
@@ -119,7 +119,7 @@ class LlmTldrIndexer:
                     LlmTldrIndexedFile.folder_path == folder_path
                 )
             )
-            db.flush()
+            db.commit()
 
         # Snapshot known state from the DB.
         existing_rows = db.execute(
@@ -148,11 +148,18 @@ class LlmTldrIndexer:
         )
 
         # Removed files: in DB, not on disk → delete their chunks + rows.
+        # Commit per file to keep each SQLite write transaction tiny. With
+        # journal_mode=DELETE the SQLite file lock is held for the whole
+        # transaction, blocking any concurrent writer (e.g. the FastAPI
+        # request handler that triggered the sync). A single transaction
+        # spanning the entire indexer pass routinely exceeds busy_timeout
+        # and surfaces as "database is locked" after partial progress.
         removed = set(existing_by_rel) - set(current_hashes)
         for rel in removed:
             self.vector_store.delete_by_folder_and_related_file(folder_path, rel)
             db.delete(existing_by_rel[rel])
             stats["files_removed"] += 1
+            db.commit()
 
         # New / changed files: extract, store, upsert row.
         for rel, source_hash in current_hashes.items():
@@ -210,8 +217,8 @@ class LlmTldrIndexer:
                 existing_row.updated_at = datetime.now(timezone.utc)
                 stats["files_updated"] += 1
             stats["chunks_stored"] += chunks_stored
+            db.commit()
 
-        db.commit()
         logger.info("llm-tldr: indexing complete for %s: %s", folder_path, stats)
         return stats
 

--- a/src/voitta/services/llm_tldr_indexer.py
+++ b/src/voitta/services/llm_tldr_indexer.py
@@ -1,0 +1,314 @@
+"""llm-tldr companion indexing.
+
+Runs `llm-tldr` static analysis over a synced Git repo and stores the
+structural summaries as companion chunks in Qdrant alongside the raw code
+chunks. Each chunk is tagged with ``source_type="llm-tldr-analysis"`` and
+``related_file`` pointing back to the originating source file.
+
+Phase 1 (PoC): delete-and-replace per sync. Incremental reindexing arrives
+in phase 2 of issue #15.
+"""
+
+import json
+import logging
+from datetime import datetime, timezone
+from pathlib import Path
+
+from sqlalchemy import delete
+from sqlalchemy.orm import Session
+
+from ..db.models import LlmTldrIndexedFile
+from .chunking import ChunkingService, get_chunking_service
+from .embedding import EmbeddingService, get_embedding_service
+from .sparse_embedding import SparseEmbeddingService, get_sparse_embedding_service
+from .vector_store import ChunkMetadata, VectorStoreService, get_vector_store
+
+logger = logging.getLogger(__name__)
+
+SOURCE_TYPE = "llm-tldr-analysis"
+
+# Subset of llm-tldr's supported extensions. Keep small for PoC; expand later.
+SUPPORTED_EXTENSIONS = {
+    ".py", ".ts", ".tsx", ".js", ".jsx", ".go", ".rs", ".java",
+    ".rb", ".php", ".swift", ".cs", ".kt", ".kts", ".scala", ".sc",
+    ".lua", ".luau", ".ex", ".exs", ".c", ".h", ".cpp", ".hpp",
+    ".cc", ".cxx", ".hh",
+}
+
+# Skip pathologically large source files — tree-sitter parsing cost grows
+# super-linearly and a single 10MB generated file would block sync.
+MAX_FILE_BYTES = 1_000_000
+
+
+class LlmTldrIndexer:
+    """Indexes llm-tldr structural analysis as companion chunks."""
+
+    def __init__(
+        self,
+        chunker: ChunkingService | None = None,
+        embedder: EmbeddingService | None = None,
+        sparse_embedder: SparseEmbeddingService | None = None,
+        vector_store: VectorStoreService | None = None,
+    ):
+        self.chunker = chunker or get_chunking_service()
+        self.embedder = embedder or get_embedding_service()
+        self.sparse_embedder = sparse_embedder or get_sparse_embedding_service()
+        self.vector_store = vector_store or get_vector_store()
+
+    def index_repo(
+        self,
+        repo_dir: Path,
+        folder_path: str,
+        index_folder: str,
+        db: Session,
+    ) -> dict:
+        """Run llm-tldr analysis over ``repo_dir`` and index companion chunks.
+
+        Args:
+            repo_dir: Local directory containing the cloned source files.
+            folder_path: Voitta-RAG folder_path the chunks belong to (e.g.
+                "myrepo/branches/main"). All companion chunks for this folder
+                are wiped and replaced.
+            index_folder: Folder at which indexing was triggered (the
+                top-level Git source folder, used for filtered searches).
+            db: Active SQLAlchemy session.
+
+        Returns:
+            Stats dict with files_analyzed, files_skipped, chunks_stored,
+            errors counts.
+        """
+        try:
+            from tldr.api import extract_file  # type: ignore
+        except ImportError as e:
+            logger.error(
+                "llm-tldr is not installed; skipping companion indexing: %s", e,
+            )
+            return {
+                "files_analyzed": 0, "files_skipped": 0,
+                "chunks_stored": 0, "errors": 1,
+            }
+
+        stats = {
+            "files_analyzed": 0, "files_skipped": 0,
+            "chunks_stored": 0, "errors": 0,
+        }
+
+        deleted = self.vector_store.delete_by_folder_and_source_type(
+            folder_path, SOURCE_TYPE,
+        )
+        logger.info(
+            "llm-tldr: wiped %d stale companion chunks for %s",
+            deleted, folder_path,
+        )
+        db.execute(
+            delete(LlmTldrIndexedFile).where(
+                LlmTldrIndexedFile.folder_path == folder_path
+            )
+        )
+        db.flush()
+
+        files = _collect_source_files(repo_dir)
+        logger.info(
+            "llm-tldr: analyzing %d source files under %s",
+            len(files), repo_dir,
+        )
+
+        for src in files:
+            rel = str(src.relative_to(repo_dir))
+            try:
+                info = extract_file(str(src), base_path=str(repo_dir))
+            except Exception as e:
+                logger.debug("llm-tldr extract failed for %s: %s", rel, e)
+                stats["files_skipped"] += 1
+                continue
+
+            text = _render_extract(rel, info)
+            if not text.strip():
+                stats["files_skipped"] += 1
+                continue
+
+            try:
+                chunks_stored = self._store_chunks(
+                    text=text,
+                    related_file=rel,
+                    folder_path=folder_path,
+                    index_folder=index_folder,
+                )
+            except Exception as e:
+                logger.exception(
+                    "llm-tldr: failed to store chunks for %s: %s", rel, e,
+                )
+                stats["errors"] += 1
+                continue
+
+            content_hash = _hash_text(text)
+            db.add(
+                LlmTldrIndexedFile(
+                    folder_path=folder_path,
+                    related_file=rel,
+                    content_hash=content_hash,
+                    chunk_count=chunks_stored,
+                )
+            )
+            stats["files_analyzed"] += 1
+            stats["chunks_stored"] += chunks_stored
+
+        db.commit()
+        logger.info("llm-tldr: indexing complete for %s: %s", folder_path, stats)
+        return stats
+
+    def _store_chunks(
+        self,
+        text: str,
+        related_file: str,
+        folder_path: str,
+        index_folder: str,
+    ) -> int:
+        chunks = self.chunker.chunk_text(text)
+        if not chunks:
+            return 0
+
+        texts = [c.text for c in chunks]
+        embeddings = self.embedder.embed_texts(texts)
+        sparse_vectors = self.sparse_embedder.embed_texts(texts)
+
+        indexed_at = datetime.now(timezone.utc).isoformat()
+        synthetic_path = f"llm-tldr://{folder_path}/{related_file}"
+        chunk_data = []
+        for chunk, embedding in zip(chunks, embeddings):
+            metadata = ChunkMetadata(
+                file_path=synthetic_path,
+                folder_path=folder_path,
+                index_folder=index_folder,
+                file_name=Path(related_file).name + ".tldr.md",
+                chunk_index=chunk.index,
+                total_chunks=len(chunks),
+                start_char=chunk.start_char,
+                end_char=chunk.end_char,
+                indexed_at=indexed_at,
+                source_type=SOURCE_TYPE,
+                related_file=related_file,
+            )
+            chunk_data.append((chunk.text, embedding, metadata))
+
+        self.vector_store.store_chunks(chunk_data, sparse_vectors=sparse_vectors)
+        return len(chunks)
+
+
+def _collect_source_files(repo_dir: Path) -> list[Path]:
+    files: list[Path] = []
+    for entry in repo_dir.rglob("*"):
+        if not entry.is_file():
+            continue
+        if any(part.startswith(".") for part in entry.relative_to(repo_dir).parts):
+            continue
+        if entry.suffix.lower() not in SUPPORTED_EXTENSIONS:
+            continue
+        try:
+            if entry.stat().st_size > MAX_FILE_BYTES:
+                continue
+        except OSError:
+            continue
+        files.append(entry)
+    return files
+
+
+def _render_extract(rel_path: str, info: dict) -> str:
+    """Render an llm-tldr extract_file dict as markdown text for chunking."""
+    lines: list[str] = []
+    lines.append(f"# llm-tldr analysis: {rel_path}")
+    lang = info.get("language") or "unknown"
+    lines.append(f"Language: {lang}")
+    docstring = info.get("docstring")
+    if docstring:
+        lines.append("")
+        lines.append("## Module docstring")
+        lines.append(docstring.strip())
+
+    imports = info.get("imports") or []
+    if imports:
+        lines.append("")
+        lines.append("## Imports")
+        for imp in imports:
+            lines.append(f"- {_render_import(imp)}")
+
+    functions = info.get("functions") or []
+    if functions:
+        lines.append("")
+        lines.append("## Functions")
+        for fn in functions:
+            lines.append(_render_function(fn))
+
+    classes = info.get("classes") or []
+    if classes:
+        lines.append("")
+        lines.append("## Classes")
+        for cls in classes:
+            lines.append(_render_class(cls))
+
+    call_graph = info.get("call_graph") or {}
+    if call_graph:
+        lines.append("")
+        lines.append("## Call graph")
+        lines.append("```json")
+        lines.append(json.dumps(call_graph, indent=2, default=str))
+        lines.append("```")
+
+    return "\n".join(lines)
+
+
+def _render_import(imp) -> str:
+    if isinstance(imp, dict):
+        module = imp.get("module") or imp.get("name") or ""
+        names = imp.get("names") or []
+        if names:
+            return f"{module} ({', '.join(map(str, names))})"
+        return str(module)
+    return str(imp)
+
+
+def _render_function(fn) -> str:
+    if not isinstance(fn, dict):
+        return f"- {fn}"
+    parts: list[str] = []
+    sig = fn.get("signature") or fn.get("name") or ""
+    parts.append(f"### {sig}")
+    if fn.get("docstring"):
+        parts.append(fn["docstring"].strip())
+    calls = fn.get("calls") or []
+    if calls:
+        parts.append(f"Calls: {', '.join(map(str, calls))}")
+    called_by = fn.get("called_by") or []
+    if called_by:
+        parts.append(f"Called by: {', '.join(map(str, called_by))}")
+    complexity = fn.get("complexity")
+    if complexity is not None:
+        parts.append(f"Cyclomatic complexity: {complexity}")
+    return "\n".join(parts)
+
+
+def _render_class(cls) -> str:
+    if not isinstance(cls, dict):
+        return f"- {cls}"
+    parts: list[str] = []
+    name = cls.get("name") or "(anonymous)"
+    bases = cls.get("bases") or cls.get("base_classes") or []
+    header = f"### class {name}"
+    if bases:
+        header += f"({', '.join(map(str, bases))})"
+    parts.append(header)
+    if cls.get("docstring"):
+        parts.append(cls["docstring"].strip())
+    methods = cls.get("methods") or []
+    for m in methods:
+        parts.append(_render_function(m))
+    return "\n".join(parts)
+
+
+def _hash_text(text: str) -> str:
+    import hashlib
+    return hashlib.sha256(text.encode("utf-8")).hexdigest()
+
+
+def get_llm_tldr_indexer() -> LlmTldrIndexer:
+    return LlmTldrIndexer()

--- a/src/voitta/services/sync/github.py
+++ b/src/voitta/services/sync/github.py
@@ -345,6 +345,28 @@ def _render_gh_run_md(run: dict, jobs: list[dict]) -> str:
     return "\n".join(lines)
 
 
+def _run_llm_tldr_indexing(local_root: Path, folder_path: str) -> dict:
+    """Run llm-tldr companion indexing in a worker thread.
+
+    Spawned via asyncio.to_thread so it can use a sync DB Session and the
+    sync embedding/vector-store services without blocking the event loop.
+    """
+    from sqlalchemy.orm import Session
+
+    from ...db.database import get_sync_engine
+    from ..llm_tldr_indexer import get_llm_tldr_indexer
+
+    indexer = get_llm_tldr_indexer()
+    engine = get_sync_engine()
+    with Session(engine) as db:
+        return indexer.index_repo(
+            repo_dir=local_root,
+            folder_path=folder_path,
+            index_folder=folder_path,
+            db=db,
+        )
+
+
 class GitHubConnector(BaseSyncConnector):
     """Sync connector that uses git clone/pull for public, SSH, and token repos."""
 
@@ -517,6 +539,9 @@ class GitHubConnector(BaseSyncConnector):
           mirrored into the local folder.
         - If gh_all_branches is set, all remote branches are synced into
           branches/<branch_name>/ subfolders.
+        - If gh_llm_tldr is set, after the mirror finishes, runs llm-tldr
+          static analysis over the synced files and stores the structural
+          summaries as companion chunks in Qdrant.
         """
         folder_path = source.folder_path
         local_root = fs._resolve_path(folder_path)
@@ -529,21 +554,28 @@ class GitHubConnector(BaseSyncConnector):
             raise ValueError("Git repository URL is required")
 
         if getattr(source, "gh_all_branches", False):
-            return await self._sync_all_branches(
+            stats = await self._sync_all_branches(
                 source, repo_url, local_root, subfolder, folder_path,
                 keep_extensions,
             )
+        else:
+            branch = source.gh_branch or "main"
+            safe_name = branch.replace("/", "--")
+            branches_dir = local_root / "branches"
+            branches_dir.mkdir(parents=True, exist_ok=True)
+            branch_root = branches_dir / safe_name
+            branch_root.mkdir(parents=True, exist_ok=True)
+            stats = await self._sync_single_branch(
+                source, repo_url, branch, branch_root, subfolder, keep_extensions,
+            )
+            logger.info("Git sync complete for %s: %s", folder_path, stats)
 
-        branch = source.gh_branch or "main"
-        safe_name = branch.replace("/", "--")
-        branches_dir = local_root / "branches"
-        branches_dir.mkdir(parents=True, exist_ok=True)
-        branch_root = branches_dir / safe_name
-        branch_root.mkdir(parents=True, exist_ok=True)
-        stats = await self._sync_single_branch(
-            source, repo_url, branch, branch_root, subfolder, keep_extensions,
-        )
-        logger.info("Git sync complete for %s: %s", folder_path, stats)
+        if getattr(source, "gh_llm_tldr", False):
+            tldr_stats = await asyncio.to_thread(
+                _run_llm_tldr_indexing, local_root, folder_path,
+            )
+            stats["llm_tldr"] = tldr_stats
+
         return stats
 
     async def _sync_all_branches(

--- a/src/voitta/services/vector_store.py
+++ b/src/voitta/services/vector_store.py
@@ -45,6 +45,17 @@ class ChunkMetadata:
     # analysis was derived from.
     source_type: str | None = None
     related_file: str | None = None
+    # llm-tldr Phase 3 — structured call-graph payload (only set on
+    # source_type == "llm-tldr-analysis" chunks). Lets Qdrant filters
+    # answer "functions with >5 callers" / "functions importing X".
+    tldr_chunk_kind: str | None = None  # "function" | "file_overview"
+    tldr_function_name: str | None = None
+    tldr_class_name: str | None = None  # for methods; None for free functions
+    tldr_callees: list[str] | None = None
+    tldr_callers: list[str] | None = None
+    tldr_caller_count: int | None = None
+    tldr_callee_count: int | None = None
+    tldr_imports: list[str] | None = None  # file-level imports, attached to each function chunk
 
 
 @dataclass
@@ -91,6 +102,7 @@ class VectorStoreService:
             self._ensure_acl_index()
             self._ensure_source_url_index()
             self._ensure_companion_chunk_indexes()
+            self._ensure_tldr_callgraph_indexes()
         except (UnexpectedResponse, Exception):
             logger.info(f"Creating collection '{self.collection_name}'")
             self._client.create_collection(
@@ -106,13 +118,13 @@ class VectorStoreService:
                 },
             )
             # Create payload indexes for efficient filtering
-            for field in ("file_path", "folder_path", "index_folder", "allowed_users", "source_url", "source_type", "related_file"):
+            for field in ("file_path", "folder_path", "index_folder", "allowed_users", "source_url", "source_type", "related_file", "tldr_chunk_kind", "tldr_function_name", "tldr_class_name", "tldr_callees", "tldr_callers", "tldr_imports"):
                 self._client.create_payload_index(
                     collection_name=self.collection_name,
                     field_name=field,
                     field_schema=qmodels.PayloadSchemaType.KEYWORD,
                 )
-            for field in ("source_created_at", "source_modified_at"):
+            for field in ("source_created_at", "source_modified_at", "tldr_caller_count", "tldr_callee_count"):
                 self._client.create_payload_index(
                     collection_name=self.collection_name,
                     field_name=field,
@@ -182,6 +194,45 @@ class VectorStoreService:
                     logger.info(f"Created index for '{field}' on '{self.collection_name}'")
         except Exception as e:
             logger.warning(f"Failed to ensure companion-chunk indexes: {e}")
+
+    def _ensure_tldr_callgraph_indexes(self) -> None:
+        """Create payload indexes for llm-tldr Phase 3 call-graph fields.
+
+        KEYWORD indexes for kind / function / class / callees / callers /
+        imports (so filters can do MatchAny). INTEGER indexes for caller
+        and callee counts (so filters can do Range, e.g. "functions with
+        >5 callers").
+        """
+        try:
+            info = self._client.get_collection(self.collection_name)
+            existing = set(info.payload_schema.keys()) if info.payload_schema else set()
+            keyword_fields = (
+                "tldr_chunk_kind",
+                "tldr_function_name",
+                "tldr_class_name",
+                "tldr_callees",
+                "tldr_callers",
+                "tldr_imports",
+            )
+            integer_fields = ("tldr_caller_count", "tldr_callee_count")
+            for field in keyword_fields:
+                if field not in existing:
+                    self._client.create_payload_index(
+                        collection_name=self.collection_name,
+                        field_name=field,
+                        field_schema=qmodels.PayloadSchemaType.KEYWORD,
+                    )
+                    logger.info(f"Created index for '{field}' on '{self.collection_name}'")
+            for field in integer_fields:
+                if field not in existing:
+                    self._client.create_payload_index(
+                        collection_name=self.collection_name,
+                        field_name=field,
+                        field_schema=qmodels.PayloadSchemaType.INTEGER,
+                    )
+                    logger.info(f"Created index for '{field}' on '{self.collection_name}'")
+        except Exception as e:
+            logger.warning(f"Failed to ensure tldr call-graph indexes: {e}")
 
     def delete_by_folder_and_related_file(
         self, folder_path: str, related_file: str,
@@ -380,6 +431,23 @@ class VectorStoreService:
                 payload["source_type"] = metadata.source_type
             if metadata.related_file is not None:
                 payload["related_file"] = metadata.related_file
+            # llm-tldr Phase 3 — call-graph payload
+            if metadata.tldr_chunk_kind is not None:
+                payload["tldr_chunk_kind"] = metadata.tldr_chunk_kind
+            if metadata.tldr_function_name is not None:
+                payload["tldr_function_name"] = metadata.tldr_function_name
+            if metadata.tldr_class_name is not None:
+                payload["tldr_class_name"] = metadata.tldr_class_name
+            if metadata.tldr_callees is not None:
+                payload["tldr_callees"] = metadata.tldr_callees
+            if metadata.tldr_callers is not None:
+                payload["tldr_callers"] = metadata.tldr_callers
+            if metadata.tldr_caller_count is not None:
+                payload["tldr_caller_count"] = metadata.tldr_caller_count
+            if metadata.tldr_callee_count is not None:
+                payload["tldr_callee_count"] = metadata.tldr_callee_count
+            if metadata.tldr_imports is not None:
+                payload["tldr_imports"] = metadata.tldr_imports
 
             # Build vector: unnamed dense + optional sparse
             if sparse_vectors and idx < len(sparse_vectors):
@@ -660,6 +728,14 @@ class VectorStoreService:
                 source_url=payload.get("source_url"),
                 source_type=payload.get("source_type"),
                 related_file=payload.get("related_file"),
+                tldr_chunk_kind=payload.get("tldr_chunk_kind"),
+                tldr_function_name=payload.get("tldr_function_name"),
+                tldr_class_name=payload.get("tldr_class_name"),
+                tldr_callees=payload.get("tldr_callees"),
+                tldr_callers=payload.get("tldr_callers"),
+                tldr_caller_count=payload.get("tldr_caller_count"),
+                tldr_callee_count=payload.get("tldr_callee_count"),
+                tldr_imports=payload.get("tldr_imports"),
             ),
             score=result.score,
         )

--- a/src/voitta/services/vector_store.py
+++ b/src/voitta/services/vector_store.py
@@ -528,7 +528,15 @@ class VectorStoreService:
         return count
 
     def get_file_paths_by_index_folder(self, index_folder: str) -> set[str]:
-        """Return all unique file_path values in Qdrant for a given index_folder."""
+        """Return all unique file_path values in Qdrant for a given index_folder.
+
+        Excludes companion chunks (chunks where ``source_type`` is set, e.g.
+        ``llm-tldr-analysis``). Companion chunks have synthetic ``file_path``
+        values (e.g. ``llm-tldr://...``) that do not appear in the
+        ``IndexedFile`` table, and including them here would make the
+        IndexingService.sync_folder orphan-cleanup pass delete every
+        companion chunk on every sync.
+        """
         file_paths: set[str] = set()
         offset = None
         while True:
@@ -539,8 +547,11 @@ class VectorStoreService:
                         qmodels.FieldCondition(
                             key="index_folder",
                             match=qmodels.MatchValue(value=index_folder),
-                        )
-                    ]
+                        ),
+                        qmodels.IsEmptyCondition(
+                            is_empty=qmodels.PayloadField(key="source_type"),
+                        ),
+                    ],
                 ),
                 limit=1000,
                 offset=offset,

--- a/src/voitta/services/vector_store.py
+++ b/src/voitta/services/vector_store.py
@@ -183,10 +183,45 @@ class VectorStoreService:
         except Exception as e:
             logger.warning(f"Failed to ensure companion-chunk indexes: {e}")
 
+    def delete_by_folder_and_related_file(
+        self, folder_path: str, related_file: str,
+    ) -> int:
+        """Delete chunks for a companion analysis tied to one source file.
+
+        Used by the incremental llm-tldr indexer when a single file is
+        changed or removed.
+        """
+        flt = qmodels.Filter(
+            must=[
+                qmodels.FieldCondition(
+                    key="folder_path",
+                    match=qmodels.MatchValue(value=folder_path),
+                ),
+                qmodels.FieldCondition(
+                    key="related_file",
+                    match=qmodels.MatchValue(value=related_file),
+                ),
+            ]
+        )
+        count_result = self.client.count(
+            collection_name=self.collection_name, count_filter=flt,
+        )
+        count = count_result.count
+        if count > 0:
+            self.client.delete(
+                collection_name=self.collection_name,
+                points_selector=qmodels.FilterSelector(filter=flt),
+            )
+            logger.info(
+                f"Deleted {count} companion chunks for "
+                f"folder={folder_path}, related_file={related_file}",
+            )
+        return count
+
     def delete_by_folder_and_source_type(self, folder_path: str, source_type: str) -> int:
         """Delete all chunks for a folder with a specific source_type.
 
-        Used to wipe llm-tldr companion chunks before re-indexing.
+        Used to wipe llm-tldr companion chunks (e.g. force reindex).
         """
         flt = qmodels.Filter(
             must=[

--- a/src/voitta/services/vector_store.py
+++ b/src/voitta/services/vector_store.py
@@ -39,6 +39,12 @@ class ChunkMetadata:
     allowed_users: list[str] | None = None
     # Source URL: original external URL (e.g. Google Docs link) for this document
     source_url: str | None = None
+    # Companion-chunk fields. When source_type is set, this chunk did not come
+    # from a literal file but from auxiliary analysis (e.g. llm-tldr static
+    # analysis). related_file points back to the original source file the
+    # analysis was derived from.
+    source_type: str | None = None
+    related_file: str | None = None
 
 
 @dataclass
@@ -84,6 +90,7 @@ class VectorStoreService:
             self._ensure_timestamp_indexes()
             self._ensure_acl_index()
             self._ensure_source_url_index()
+            self._ensure_companion_chunk_indexes()
         except (UnexpectedResponse, Exception):
             logger.info(f"Creating collection '{self.collection_name}'")
             self._client.create_collection(
@@ -99,7 +106,7 @@ class VectorStoreService:
                 },
             )
             # Create payload indexes for efficient filtering
-            for field in ("file_path", "folder_path", "index_folder", "allowed_users", "source_url"):
+            for field in ("file_path", "folder_path", "index_folder", "allowed_users", "source_url", "source_type", "related_file"):
                 self._client.create_payload_index(
                     collection_name=self.collection_name,
                     field_name=field,
@@ -159,6 +166,53 @@ class VectorStoreService:
                 logger.info(f"Created index for 'source_url' on '{self.collection_name}'")
         except Exception as e:
             logger.warning(f"Failed to ensure source_url index: {e}")
+
+    def _ensure_companion_chunk_indexes(self) -> None:
+        """Create KEYWORD payload indexes for source_type and related_file if missing."""
+        try:
+            info = self._client.get_collection(self.collection_name)
+            existing = set(info.payload_schema.keys()) if info.payload_schema else set()
+            for field in ("source_type", "related_file"):
+                if field not in existing:
+                    self._client.create_payload_index(
+                        collection_name=self.collection_name,
+                        field_name=field,
+                        field_schema=qmodels.PayloadSchemaType.KEYWORD,
+                    )
+                    logger.info(f"Created index for '{field}' on '{self.collection_name}'")
+        except Exception as e:
+            logger.warning(f"Failed to ensure companion-chunk indexes: {e}")
+
+    def delete_by_folder_and_source_type(self, folder_path: str, source_type: str) -> int:
+        """Delete all chunks for a folder with a specific source_type.
+
+        Used to wipe llm-tldr companion chunks before re-indexing.
+        """
+        flt = qmodels.Filter(
+            must=[
+                qmodels.FieldCondition(
+                    key="folder_path",
+                    match=qmodels.MatchValue(value=folder_path),
+                ),
+                qmodels.FieldCondition(
+                    key="source_type",
+                    match=qmodels.MatchValue(value=source_type),
+                ),
+            ]
+        )
+        count_result = self.client.count(
+            collection_name=self.collection_name, count_filter=flt,
+        )
+        count = count_result.count
+        if count > 0:
+            self.client.delete(
+                collection_name=self.collection_name,
+                points_selector=qmodels.FilterSelector(filter=flt),
+            )
+            logger.info(
+                f"Deleted {count} '{source_type}' chunks for folder: {folder_path}"
+            )
+        return count
 
     def find_by_source_url(self, source_url: str) -> list[StoredChunk]:
         """Find all chunks matching a given source_url.
@@ -286,6 +340,11 @@ class VectorStoreService:
             # Add source URL if present
             if metadata.source_url is not None:
                 payload["source_url"] = metadata.source_url
+            # Add companion-chunk fields if present
+            if metadata.source_type is not None:
+                payload["source_type"] = metadata.source_type
+            if metadata.related_file is not None:
+                payload["related_file"] = metadata.related_file
 
             # Build vector: unnamed dense + optional sparse
             if sparse_vectors and idx < len(sparse_vectors):
@@ -553,6 +612,8 @@ class VectorStoreService:
                 source_modified_at=payload.get("source_modified_at"),
                 allowed_users=payload.get("allowed_users"),
                 source_url=payload.get("source_url"),
+                source_type=payload.get("source_type"),
+                related_file=payload.get("related_file"),
             ),
             score=result.score,
         )

--- a/src/voitta/services/vector_store.py
+++ b/src/voitta/services/vector_store.py
@@ -82,10 +82,21 @@ class VectorStoreService:
 
     @property
     def client(self) -> QdrantClient:
-        """Lazy load the Qdrant client."""
+        """Lazy load the Qdrant client.
+
+        qdrant-client defaults its HTTP timeout to 5 seconds, which is
+        fine for vector search but too tight for filtered ``delete`` /
+        ``count`` against a large collection — payload-index filter
+        compilation alone routinely takes >5s on collections with
+        >1M points. The llm-tldr companion indexer (Phase 2+) issues
+        per-file ``delete`` calls; raising the timeout keeps those
+        within budget without making fast paths any slower.
+        """
         if self._client is None:
             logger.info(f"Connecting to Qdrant at {self.host}:{self.port}")
-            self._client = QdrantClient(host=self.host, port=self.port)
+            self._client = QdrantClient(
+                host=self.host, port=self.port, timeout=60,
+            )
             self._ensure_collection()
         return self._client
 

--- a/src/voitta/web/templates/browser.html
+++ b/src/voitta/web/templates/browser.html
@@ -318,6 +318,12 @@
                             <input type="password" id="gh-pat" class="sync-input" placeholder="ghp_... or github_pat_..." onblur="fetchGitBranches()">
                         </div>
                     </div>
+                    <div class="form-group-compact">
+                        <label style="display:flex; align-items:center; gap:6px; font-size:12px; cursor:pointer;">
+                            <input type="checkbox" id="gh-llm-tldr">
+                            Run llm-tldr static analysis (indexes structural summaries alongside code)
+                        </label>
+                    </div>
                 </div>
 
                 <!-- Azure DevOps Fields -->

--- a/static/js/app.js
+++ b/static/js/app.js
@@ -1067,6 +1067,7 @@ function populateSyncFields(data) {
         document.getElementById('gh-username').value = data.github.username || '';
         document.getElementById('gh-pat').value = data.github.token || '';
         document.getElementById('gh-all-branches').checked = !!data.github.all_branches;
+        document.getElementById('gh-llm-tldr').checked = !!data.github.llm_tldr;
         toggleGhAuth();
         toggleAllBranches();
         // Fetch branches and pre-select the saved one
@@ -1309,6 +1310,7 @@ function gatherSyncConfig() {
             username: document.getElementById('gh-username').value.trim(),
             token: document.getElementById('gh-pat').value.trim(),
             all_branches: document.getElementById('gh-all-branches').checked,
+            llm_tldr: document.getElementById('gh-llm-tldr').checked,
         };
     } else if (sourceType === 'azure_devops') {
         config.azure_devops = {


### PR DESCRIPTION
## Summary

Closes #15.

Indexes `llm-tldr` static-analysis output as companion documents
alongside the raw code chunks voitta-rag already stores for Git
sources. When a Git source has the new `gh_llm_tldr` flag enabled,
sync runs `llm-tldr` over every supported source file in the synced
tree and stores per-function structural summaries (signature,
docstring, callers, callees, imports) in the same Qdrant collection.
Each companion chunk is tagged `source_type="llm-tldr-analysis"` and
keeps a `related_file` pointer back to its origin.

Agents that search voitta-rag now get raw code AND structural context
from a single query, with no tool-switching. The function-level chunk
payload also supports filtered searches like "functions with >5
callers" or "functions importing module X" — a GitNexus-shaped
knowledge graph approximation without a separate graph database.

## What lands

Nine squashed commits on this branch — one per phase + the small
fixes that came out of manual testing:

- **#31 — Phase 1** — PoC: `gh_llm_tldr` flag, file-level analysis
  chunks, ChunkMetadata `source_type` + `related_file`, indexer hook
  inside `GitHubConnector.sync()`. Delete-and-replace per sync.
- **#32 — Phase 2** — Incremental reindex: SHA-256 of source bytes
  in `LlmTldrIndexedFile.content_hash`; per-file diff against current
  on-disk hashes; `force=True` for full rebuilds; counters
  `files_new`/`files_updated`/`files_removed`/`files_unchanged`.
  Skipped `tldr daemon notify` (no daemon-side state to invalidate
  when using `tldr.api.extract_file` directly).
- **#34 — Phase 2.5** — Unblock testing on bind-mounted SQLite. Drop
  `PRAGMA journal_mode=WAL` on every connect (let the file decide;
  operators can pick `DELETE` once, host-side, and it sticks). Guard
  the `_discover_docker_folders` marking loop on
  `source_type == "filesystem"` so non-filesystem sources don't get
  locked as undeletable.
- **#35 — Phase 2.7** — Exclude companion chunks from
  `IndexingService.sync_folder`'s orphan-cleanup pass. Without this,
  every sync was purging the analysis chunks the indexer had just
  inserted.
- **#36 — Phase 2.8** — Commit per file inside the indexer. The
  Phase 2 single-end-of-loop commit held the SQLite file lock for
  the duration of the indexer pass; under `journal_mode=DELETE` that
  routinely exceeded `busy_timeout` and surfaced as `database is
  locked`.
- **#37 — Phase 2.9** — Release the async DB session held by
  `_run_sync` during the long-running `connector.sync()` call. The
  initial `SELECT` pinned a shared lock that, under `DELETE`,
  blocked the indexer's writes. Refactor into three short DB
  windows around the long-running work.
- **#38 — Phase 3** — Structured call-graph payload + function-level
  chunking. Eight new `ChunkMetadata` fields:
  `tldr_chunk_kind`, `tldr_function_name`, `tldr_class_name`,
  `tldr_callees`, `tldr_callers`, `tldr_caller_count`,
  `tldr_callee_count`, `tldr_imports`. KEYWORD indexes on the
  list/scalar fields, INTEGER on the two counts. Cyclomatic
  complexity deferred — lives in llm-tldr's CFG layer.
  `ANALYSIS_FORMAT_VERSION = "v3"` mixed into the file hash so
  Phase 2 incremental indexer treats every file as changed on the
  first sync after deploy.
- **#39 — Phase 3.1** — Bump qdrant-client HTTP timeout from
  default 5s to 60s. Filtered delete on a >1M-point collection
  needs the headroom.
- **#40 — Phase 4** — Git post-commit hook. New endpoint
  `POST /api/sync/_hook/sync/{folder_path}` authenticated by
  shared-secret `X-Voitta-Hook-Secret` header
  (`VOITTA_HOOK_SECRET` env var, opt-in — returns 403 when unset).
  `scripts/git-hooks/post-commit` bash template + README docs.

## Schema changes

- New SQLite column `folder_sync_sources.gh_llm_tldr BOOLEAN` (handled
  by the existing `_migrate_missing_columns` helper).
- New SQLite table `llm_tldr_indexed_files`.
- New Qdrant KEYWORD indexes: `source_type`, `related_file`,
  `tldr_chunk_kind`, `tldr_function_name`, `tldr_class_name`,
  `tldr_callees`, `tldr_callers`, `tldr_imports`.
- New Qdrant INTEGER indexes: `tldr_caller_count`,
  `tldr_callee_count`.
- New SQLite `PRAGMA journal_mode` left untouched at connect time
  (operator-controlled); existing deployments unchanged unless an
  operator opts in to `DELETE`.

## New deps

- `llm-tldr>=0.1.0` added to `requirements.txt` + `pyproject.toml`.

## Phase 5 (blog post) — separate issue

The blog post promised in the issue body is filed as its own ticket
so this PR stays focused on the code. See [voitta-ai/voitta-rag#42]
(filed alongside this PR).

## Manual test results (voitta-rag itself, ~70 .py files)

- Fresh sync with the flag on: `files_new=70`, `chunks_stored=647`
  (70 file_overview + 577 function chunks).
- Re-sync idempotent: 70 files unchanged, zero new rows, zero
  Qdrant writes, zero orphan purges.
- Range filter `tldr_caller_count >= 5` → 9 chunks, 2.5ms.
- Match filter `tldr_imports = "sqlalchemy.orm"` → 89 chunks,
  5.7ms.
- Hook endpoint: 4/4 acceptance curl tests pass (no header → 403,
  wrong secret → 403, unknown folder → 404, real folder → 200 +
  sync fires).

Closes #15

