### PR TITLE
fix(session-memory): redact credential-shaped strings before persisting a session

### DIFF
--- a/claude-plugin/hooks/session-memory.py
+++ b/claude-plugin/hooks/session-memory.py
@@ -3,7 +3,8 @@
 
 Reads hook input JSON from stdin, then reads the transcript JSONL file pointed
 to by transcript_path. Extracts user prompts and assistant text responses,
-formats them as markdown, and POSTs to voitta-rag's create_memory MCP tool.
+formats them as markdown, redacts credential-shaped substrings, and POSTs to
+voitta-rag's create_memory MCP tool.
 
 Configured via env vars (set by setup.sh):
     VOITTA_URL   voitta-rag base URL (default: http://localhost:8000)
@@ -15,6 +16,7 @@ break the user's session close on a memory save error.
 
 import json
 import os
+import re
 import sys
 from datetime import datetime, timezone
 from pathlib import Path
@@ -95,6 +97,57 @@ def _flatten_assistant_content(content) -> str:
                 parts.append(part.get("text", ""))
         return "\n".join(p for p in parts if p).strip()
     return ""
+
+
+REDACTED = "[REDACTED-SECRET]"
+
+# Credential shapes to strip before a transcript is persisted and embedded.
+# A memory store is long-lived and retrievable, so anything that lands here can
+# resurface in a later session's context long after the original secret was
+# rotated -- or, worse, before.
+#
+# Ordered so that longer prefixes match first: github_pat_ must be tried before
+# the shorter gh?_ forms, or it gets half-eaten.
+_SECRET_PATTERNS = [
+    re.compile(r"github_pat_[A-Za-z0-9_]{20,}"),
+    re.compile(r"gh[pousr]_[A-Za-z0-9]{20,}"),
+    re.compile(r"glpat-[A-Za-z0-9\-_]{20,}"),
+    # Slack: xox?- are bot/user/app tokens, xapp- is an app-level token,
+    # which is a different shape and is easy to miss.
+    re.compile(r"xox[baprse]-[A-Za-z0-9\-]{10,}"),
+    re.compile(r"xapp-[0-9]-[A-Za-z0-9\-]{10,}"),
+    re.compile(r"(?:AKIA|ASIA)[0-9A-Z]{16}"),
+    re.compile(r"sk-[A-Za-z0-9]{20,}"),
+    re.compile(
+        r"-----BEGIN [A-Z ]*PRIVATE KEY-----.*?-----END [A-Z ]*PRIVATE KEY-----",
+        re.DOTALL,
+    ),
+    # URLs of the form scheme://user:secret@host, which is how a PAT ends up in
+    # a git remote and therefore in any transcript that echoed one.
+    re.compile(r"(?<=://)([^/\s:@]+):([^/\s@]+)(?=@)"),
+]
+
+# Assignment-shaped secrets: redact only the value, keep the name so the
+# surrounding text still reads.
+_SECRET_ASSIGNMENT = re.compile(
+    r"(?i)\b(api[_-]?key|secret|password|passwd|token)\b(\s*[=:]\s*[\"']?)"
+    r"([A-Za-z0-9/+=_\-]{16,})",
+)
+
+
+def redact_secrets(text: str) -> str:
+    """Replace credential-shaped substrings with a marker.
+
+    Deliberately conservative about what it keeps: a false positive costs a
+    little readability in a stored memory, a false negative persists a live
+    credential in an embedded, searchable store.
+    """
+    for pattern in _SECRET_PATTERNS[:-1]:
+        text = pattern.sub(REDACTED, text)
+    text = _SECRET_PATTERNS[-1].sub(r"\1:" + REDACTED, text)
+    text = _SECRET_ASSIGNMENT.sub(r"\1\2" + REDACTED, text)
+    retval = text
+    return retval
 
 
 def format_memory(session_id: str, cwd: str, reason: str, turns: list[dict]) -> str:
@@ -200,7 +253,7 @@ def main() -> int:
         print("voitta-rag session-memory: no user/assistant turns — skipping", file=sys.stderr)
         return 0
 
-    content = format_memory(session_id, cwd, reason, turns)
+    content = redact_secrets(format_memory(session_id, cwd, reason, turns))
 
     voitta_url = os.environ.get("VOITTA_URL", "http://localhost:8000")
     voitta_user = os.environ.get("VOITTA_USER", os.environ.get("USER", "anonymous"))


### PR DESCRIPTION
## The gap

`claude-plugin/hooks/session-memory.py` reads the Claude Code transcript on session end, extracts every user prompt and assistant response, and POSTs them verbatim to `create_memory`. Grepping the hook for `redact|scrub|sanitiz|secret|token` returns **zero** — there is no filtering of any kind.

A memory store is long-lived, embedded and retrievable, so anything that lands there can resurface in a later session's context long after the original secret was rotated — or before. That is not hypothetical: **this was found because tokens had already accumulated in a real Anamnesis store.**

Worth noting what limits the blast radius: the hook extracts user prompts and assistant *text* only, not tool results. So a secret that appeared solely in command output is not captured; one that was pasted in, or that the assistant echoed back in prose, is. That makes redaction a tractable ask rather than a boil-the-ocean one.

## The change

One function, `redact_secrets()`, applied to the formatted content immediately before the POST. Covers:

- GitHub classic (`ghp_`/`gho_`/`ghs_`/`ghu_`/`ghr_`) and fine-grained (`github_pat_`) PATs
- GitLab `glpat-`
- Slack `xox?-` and `xapp-`
- AWS `AKIA`/`ASIA` access key ids
- OpenAI-style `sk-`
- PEM private key blocks
- credentials in `scheme://user:secret@host` URLs — how a PAT reaches a git remote, and therefore a transcript
- assignment-shaped secrets (`X-Api-Key: …`, `token=…`), where only the **value** is replaced so the surrounding text still reads

Deliberately biased toward over-redaction: a false positive costs a little readability in a stored memory; a false negative persists a live credential in a searchable store.

## Verification

Run against **482 real session memories, 730,719 lines**:

| | |
|---|---|
| files changed | **2** |
| false positives | **0** |
| both changes | genuine secrets — an `X-Api-Key` and a Slack bot token |

Negatives that survive untouched include text a naive pattern would mangle: IAM ARNs with long numeric account ids, ISO-8601 durations like `PT600S`, ordinary prose with issue and PR numbers.

The `xapp-` shape was **added after** that run — the first pass caught the `xoxb-` bot token and left the `xapp-` app-level token on the same line untouched, which is exactly the kind of near-miss this is meant to prevent.

## No test

`claude-plugin/hooks` has no test infrastructure today, and this change isn't the place to introduce one. The verification above is reproducible against any transcript directory — happy to add a `tests/` case if you'd rather have it in CI.


Closes #54
